### PR TITLE
Add Home Page 

### DIFF
--- a/Dynavity/Dynavity/DynavityApp.swift
+++ b/Dynavity/Dynavity/DynavityApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct DynavityApp: App {
     var body: some Scene {
         WindowGroup {
-            MainView()
+            HomeView()
         }
     }
 }

--- a/Dynavity/Dynavity/view/CanvasSelectionView.swift
+++ b/Dynavity/Dynavity/view/CanvasSelectionView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct CanvasSelectionView: View {
     @Binding var canvases: [String]
+    @Binding var searchQuery: String
 
     let columns = [
         GridItem(.flexible()),
@@ -13,7 +14,13 @@ struct CanvasSelectionView: View {
     var body: some View {
         ScrollView {
             LazyVGrid(columns: columns, spacing: 200) {
-                ForEach(canvases, id: \.self) { canvas in
+                let filteredCanvases = canvases.filter {
+                    if searchQuery.isEmpty {
+                        return true
+                    }
+                    return $0.lowercased().contains(self.searchQuery.lowercased())
+                }
+                ForEach(filteredCanvases, id: \.self) { canvas in
                     CanvasThumbnailView(canvasName: canvas)
                 }
             }
@@ -24,6 +31,6 @@ struct CanvasSelectionView: View {
 
 struct CanvasSelectionView_Previews: PreviewProvider {
     static var previews: some View {
-        CanvasSelectionView(canvases: .constant([]))
+        CanvasSelectionView(canvases: .constant([]), searchQuery: .constant(""))
     }
 }

--- a/Dynavity/Dynavity/view/CanvasSelectionView.swift
+++ b/Dynavity/Dynavity/view/CanvasSelectionView.swift
@@ -1,8 +1,7 @@
 import SwiftUI
 
 struct CanvasSelectionView: View {
-    // TODO: replace this with list of canvases
-    let data = (1...100).map { "Item \($0)" }
+    @Binding var canvases: [String]
 
     let columns = [
         GridItem(.flexible()),
@@ -14,8 +13,8 @@ struct CanvasSelectionView: View {
     var body: some View {
         ScrollView {
             LazyVGrid(columns: columns, spacing: 200) {
-                ForEach(data, id: \.self) { _ in
-                    CanvasThumbnailView()
+                ForEach(canvases, id: \.self) { canvas in
+                    CanvasThumbnailView(canvasName: canvas)
                 }
             }
             .padding(.horizontal)
@@ -25,6 +24,6 @@ struct CanvasSelectionView: View {
 
 struct CanvasSelectionView_Previews: PreviewProvider {
     static var previews: some View {
-        CanvasSelectionView()
+        CanvasSelectionView(canvases: .constant([]))
     }
 }

--- a/Dynavity/Dynavity/view/CanvasSelectionView.swift
+++ b/Dynavity/Dynavity/view/CanvasSelectionView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct CanvasSelectionView: View {
     @Binding var canvases: [String]
-    @Binding var searchQuery: String
+    @State var searchQuery: String = ""
 
     let columns = [
         GridItem(.flexible()),
@@ -11,26 +11,45 @@ struct CanvasSelectionView: View {
         GridItem(.flexible())
     ]
 
+    var filteredCanvases: [String] {
+        canvases.filter {
+            if searchQuery.isEmpty {
+                return true
+            }
+            return $0.lowercased().contains(self.searchQuery.lowercased())
+        }
+    }
+
     var body: some View {
-        ScrollView {
-            LazyVGrid(columns: columns, spacing: 200) {
-                let filteredCanvases = canvases.filter {
-                    if searchQuery.isEmpty {
-                        return true
-                    }
-                    return $0.lowercased().contains(self.searchQuery.lowercased())
+        NavigationView {
+            VStack {
+                SearchBar(text: $searchQuery)
+                    .padding()
+                ScrollView {
+                    canvasesGrid
                 }
-                ForEach(filteredCanvases, id: \.self) { canvas in
+            }
+            .navigationBarHidden(true)
+        }
+        .navigationViewStyle(StackNavigationViewStyle())
+    }
+
+    var canvasesGrid: some View {
+        LazyVGrid(columns: columns, spacing: 200) {
+            ForEach(self.filteredCanvases, id: \.self) { canvas in
+                NavigationLink(destination: MainView()
+                                .navigationBarHidden(true)
+                                .navigationBarBackButtonHidden(true)) {
                     CanvasThumbnailView(canvasName: canvas)
                 }
             }
-            .padding(.horizontal)
         }
+        .padding(.horizontal)
     }
 }
 
 struct CanvasSelectionView_Previews: PreviewProvider {
     static var previews: some View {
-        CanvasSelectionView(canvases: .constant([]), searchQuery: .constant(""))
+        CanvasSelectionView(canvases: .constant([]))
     }
 }

--- a/Dynavity/Dynavity/view/CanvasSelectionView.swift
+++ b/Dynavity/Dynavity/view/CanvasSelectionView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct CanvasSelectionView: View {
+    // TODO: replace this with list of canvases
+    let data = (1...100).map { "Item \($0)" }
+
+    let columns = [
+        GridItem(.flexible()),
+        GridItem(.flexible()),
+        GridItem(.flexible()),
+        GridItem(.flexible())
+    ]
+
+    var body: some View {
+        ScrollView {
+            LazyVGrid(columns: columns, spacing: 200) {
+                ForEach(data, id: \.self) { _ in
+                    CanvasThumbnailView()
+                }
+            }
+            .padding(.horizontal)
+        }
+    }
+}
+
+struct CanvasSelectionView_Previews: PreviewProvider {
+    static var previews: some View {
+        CanvasSelectionView()
+    }
+}

--- a/Dynavity/Dynavity/view/HomeView.swift
+++ b/Dynavity/Dynavity/view/HomeView.swift
@@ -5,15 +5,6 @@ struct HomeView: View {
     @State var canvases: [String] = (1...100).map { "Canvas \($0)" }
     @State var searchQuery: String = ""
 
-    init() {
-        self.canvases = self.canvases.filter {
-            if searchQuery.isEmpty {
-                return true
-            }
-            return $0.lowercased().contains(self.searchQuery.lowercased())
-        }
-    }
-
     var body: some View {
         SearchBar(text: $searchQuery)
             .padding()

--- a/Dynavity/Dynavity/view/HomeView.swift
+++ b/Dynavity/Dynavity/view/HomeView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct HomeView: View {
+    // TODO: replace this with list of actual canvases
+    @State var canvases: [String] = (1...100).map { "Canvas \($0)" }
+    @State var searchQuery: String = ""
+
+    var body: some View {
+        SearchBar(text: .constant(""))
+            .padding()
+        CanvasSelectionView(canvases: $canvases)
+    }
+}
+
+struct HomeView_Previews: PreviewProvider {
+    static var previews: some View {
+        HomeView()
+    }
+}

--- a/Dynavity/Dynavity/view/HomeView.swift
+++ b/Dynavity/Dynavity/view/HomeView.swift
@@ -5,10 +5,19 @@ struct HomeView: View {
     @State var canvases: [String] = (1...100).map { "Canvas \($0)" }
     @State var searchQuery: String = ""
 
+    init() {
+        self.canvases = self.canvases.filter {
+            if searchQuery.isEmpty {
+                return true
+            }
+            return $0.lowercased().contains(self.searchQuery.lowercased())
+        }
+    }
+
     var body: some View {
-        SearchBar(text: .constant(""))
+        SearchBar(text: $searchQuery)
             .padding()
-        CanvasSelectionView(canvases: $canvases)
+        CanvasSelectionView(canvases: $canvases, searchQuery: $searchQuery)
     }
 }
 

--- a/Dynavity/Dynavity/view/HomeView.swift
+++ b/Dynavity/Dynavity/view/HomeView.swift
@@ -3,12 +3,9 @@ import SwiftUI
 struct HomeView: View {
     // TODO: replace this with list of actual canvases
     @State var canvases: [String] = (1...100).map { "Canvas \($0)" }
-    @State var searchQuery: String = ""
 
     var body: some View {
-        SearchBar(text: $searchQuery)
-            .padding()
-        CanvasSelectionView(canvases: $canvases, searchQuery: $searchQuery)
+        CanvasSelectionView(canvases: $canvases)
     }
 }
 

--- a/Dynavity/Dynavity/view/SearchBar.swift
+++ b/Dynavity/Dynavity/view/SearchBar.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct SearchBar: UIViewRepresentable {
+    @Binding var text: String
+
+    func makeUIView(context: UIViewRepresentableContext<SearchBar>) -> UISearchBar {
+        let searchBar = UISearchBar(frame: .zero)
+        searchBar.delegate = context.coordinator
+        searchBar.placeholder = "Search"
+        searchBar.searchBarStyle = .minimal
+        searchBar.autocapitalizationType = .none
+        return searchBar
+    }
+
+    func updateUIView(_ uiView: UISearchBar, context: UIViewRepresentableContext<SearchBar>) {
+        uiView.text = text
+    }
+
+    final class Coordinator: NSObject, UISearchBarDelegate {
+        @Binding var text: String
+
+        init(text: Binding<String>) {
+            self._text = text
+        }
+
+        func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+            self.text = searchText
+        }
+    }
+
+    func makeCoordinator() -> SearchBar.Coordinator {
+        Coordinator(text: $text)
+    }
+}
+
+struct SearchBar_Previews: PreviewProvider {
+    static var previews: some View {
+        SearchBar(text: .constant(""))
+    }
+}

--- a/Dynavity/Dynavity/view/canvas/CanvasThumbnailView.swift
+++ b/Dynavity/Dynavity/view/canvas/CanvasThumbnailView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct CanvasThumbnailView: View {
+    var body: some View {
+        VStack {
+            // TODO: replace this with canvas thumbnail
+            Image(systemName: "doc")
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: 70)
+            Text("Canvas Name")
+        }
+    }
+}
+
+struct CanvasThumbnailView_Previews: PreviewProvider {
+    static var previews: some View {
+        CanvasThumbnailView()
+    }
+}

--- a/Dynavity/Dynavity/view/canvas/CanvasThumbnailView.swift
+++ b/Dynavity/Dynavity/view/canvas/CanvasThumbnailView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct CanvasThumbnailView: View {
+    var canvasName: String
     var body: some View {
         VStack {
             // TODO: replace this with canvas thumbnail
@@ -8,13 +9,13 @@ struct CanvasThumbnailView: View {
                 .resizable()
                 .aspectRatio(contentMode: .fill)
                 .frame(width: 70)
-            Text("Canvas Name")
+            Text(canvasName)
         }
     }
 }
 
 struct CanvasThumbnailView_Previews: PreviewProvider {
     static var previews: some View {
-        CanvasThumbnailView()
+        CanvasThumbnailView(canvasName: "")
     }
 }


### PR DESCRIPTION
Changes
- Add a Home Page, which contains a canvas selection view along with a search bar
- Filtering logic of canvases based on search term should be working, though it's currently only tested with a `String` instead of the actual `Canvas` model.
- A canvas in the Canvas Selection View is currently a document icon and its name. The document icon is likely to be replaced with some thumbnail of the actual canvas (probably requires the Storage implementation to be out first before this can be done)
- Tapping on any canvas in the Canvas Selection View will take you to the canvas editing view. There is currently no way to go back to home page once you have selected a canvas (i've disabled the back button in the NavigationView because it doesn't play well with our toolbar)

![IMG_0014](https://user-images.githubusercontent.com/24363622/111795532-41b12380-8902-11eb-86b2-0332e47de5bf.PNG)

