### PR TITLE
Fix zoom bug

### DIFF
--- a/Dynavity/Dynavity/view/canvas/CanvasView.swift
+++ b/Dynavity/Dynavity/view/canvas/CanvasView.swift
@@ -58,6 +58,7 @@ extension CanvasView: UIViewRepresentable {
         annotationCanvasView.contentSize = CGSize(width: maxContentSize, height: maxContentSize)
         annotationCanvasView.minimumZoomScale = CGFloat(0.1)
         annotationCanvasView.maximumZoomScale = CGFloat(2.0)
+        annotationCanvasView.bouncesZoom = false
 
         scrollToInitialContentOffset()
         showToolPicker()


### PR DESCRIPTION
## Changes Made
- Added a workaround that solves the disappearing and reappearing animation of the `CanvasElementMapView` elements when the user zoom's past the maximum or minimum zoom scale (issue highlighted in #12 ). 