### PR TITLE
Add PDF canvas element

### DIFF
--- a/Dynavity/Dynavity/Info.plist
+++ b/Dynavity/Dynavity/Info.plist
@@ -41,6 +41,8 @@
 	</array>
 	<key>NSCameraUsageDescription</key>
 	<string>This app requires camera access to capture photos.</string>
+	<key>NSDocumentsFolderUsageDescription</key>
+	<string>This app requires documents folder access to import documents.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>This app requires photo library access to import photos.</string>
 	<key>UISupportedInterfaceOrientations~ipad</key>

--- a/Dynavity/Dynavity/model/CGPoint+canvasCenter.swift
+++ b/Dynavity/Dynavity/model/CGPoint+canvasCenter.swift
@@ -1,0 +1,5 @@
+import SwiftUI
+
+extension CGPoint {
+    public static var canvasCenter = Self(x: 250_000, y: 250_000)
+}

--- a/Dynavity/Dynavity/model/canvas/elements/ImageCanvasElement.swift
+++ b/Dynavity/Dynavity/model/canvas/elements/ImageCanvasElement.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct ImageCanvasElement: CanvasElementProtocol {
     var id = UUID()
-    var position: CGPoint = .zero
+    var position: CGPoint = .canvasCenter
     var image: UIImage
 }
 

--- a/Dynavity/Dynavity/model/canvas/elements/PDFCanvasElement.swift
+++ b/Dynavity/Dynavity/model/canvas/elements/PDFCanvasElement.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct PDFCanvasElement: CanvasElementProtocol {
     var id = UUID()
     var position: CGPoint = .zero
-    var url: URL
+    var file: URL
 }
 
 // MARK: Equatable

--- a/Dynavity/Dynavity/model/canvas/elements/PDFCanvasElement.swift
+++ b/Dynavity/Dynavity/model/canvas/elements/PDFCanvasElement.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+struct PDFCanvasElement: CanvasElementProtocol {
+    var id = UUID()
+    var position: CGPoint = .zero
+    var url: URL
+}
+
+// MARK: Equatable
+extension PDFCanvasElement: Equatable {}

--- a/Dynavity/Dynavity/model/canvas/elements/PDFCanvasElement.swift
+++ b/Dynavity/Dynavity/model/canvas/elements/PDFCanvasElement.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct PDFCanvasElement: CanvasElementProtocol {
     var id = UUID()
-    var position: CGPoint = .zero
+    var position: CGPoint = .canvasCenter
     var file: URL
 }
 

--- a/Dynavity/Dynavity/model/canvas/elements/TextBlock.swift
+++ b/Dynavity/Dynavity/model/canvas/elements/TextBlock.swift
@@ -4,7 +4,7 @@ import Foundation
 struct TextBlock: CanvasElementProtocol {
     // TODO: replace these with actual values
     var id = UUID()
-    var position: CGPoint = .zero
+    var position: CGPoint = .canvasCenter
     var text: String = ""
     var fontSize: CGFloat = 14
 }

--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
@@ -9,6 +9,12 @@ import SwiftUI
 
 class CanvasViewModel: ObservableObject {
     @Published var canvas = Canvas()
+
+    // Sheets
+    @Published var activeSheet: ToolbarView.ActiveSheet?
+    private var lastActiveSheet: ToolbarView.ActiveSheet?
+
+    // Selected media
     @Published var selectedImage: UIImage?
     @Published var selectedFile: URL?
 
@@ -42,5 +48,36 @@ class CanvasViewModel: ObservableObject {
 
     func addMarkUpTextBlock(markupType: MarkupTextBlock.MarkupType) {
         canvas.addElement(MarkupTextBlock(markupType: markupType))
+    }
+}
+
+// MARK: Sheets
+extension CanvasViewModel {
+    func displayCamera() {
+        activeSheet = .camera
+        lastActiveSheet = .camera
+    }
+
+    func displayPhotoGallery() {
+        activeSheet = .photoGallery
+        lastActiveSheet = .photoGallery
+    }
+
+    func displayPdfPicker() {
+        activeSheet = .pdfPicker
+        lastActiveSheet = .pdfPicker
+    }
+
+    func handleSheetDismiss() {
+        switch lastActiveSheet {
+        case .camera:
+            addImageCanvasElement()
+        case .photoGallery:
+            addImageCanvasElement()
+        case .pdfPicker:
+            addPdfCanvasElement()
+        default:
+            assert(false, "When `handleSheetDismiss` is called, `lastActiveSheet` should not be `nil`.")
+        }
     }
 }

--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
@@ -10,6 +10,7 @@ import SwiftUI
 class CanvasViewModel: ObservableObject {
     @Published var canvas = Canvas()
     @Published var selectedImage: UIImage?
+    @Published var selectedFile: URL?
 
     func addImageCanvasElement() {
         guard let image = selectedImage else {

--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
@@ -5,40 +5,14 @@ class CanvasViewModel: ObservableObject {
     @Published var canvas = Canvas()
     @Published var annotationCanvas = AnnotationCanvas()
 
-    // Selected media
-    @Published var selectedImage: UIImage? {
-        didSet {
-            addImageCanvasElement()
-        }
-    }
-    @Published var selectedFile: URL? {
-        didSet {
-            addPdfCanvasElement()
-        }
-    }
-
-    func addImageCanvasElement() {
-        guard let image = selectedImage else {
-            return
-        }
-
+    func addImageCanvasElement(from image: UIImage) {
         let imageCanvasElement = ImageCanvasElement(image: image)
         canvas.addElement(imageCanvasElement)
-
-        // Reset the selected image.
-        selectedImage = nil
     }
 
-    func addPdfCanvasElement() {
-        guard let file = selectedFile else {
-            return
-        }
-
+    func addPdfCanvasElement(from file: URL) {
         let pdfCanvasElement = PDFCanvasElement(file: file)
         canvas.addElement(pdfCanvasElement)
-
-        // Reset the selected file.
-        selectedFile = nil
     }
 
     func addTextBlock() {

--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
@@ -10,13 +10,17 @@ import SwiftUI
 class CanvasViewModel: ObservableObject {
     @Published var canvas = Canvas()
 
-    // Sheets
-    @Published var activeSheet: ToolbarView.ActiveSheet?
-    private var lastActiveSheet: ToolbarView.ActiveSheet?
-
     // Selected media
-    @Published var selectedImage: UIImage?
-    @Published var selectedFile: URL?
+    @Published var selectedImage: UIImage? {
+        didSet {
+            addImageCanvasElement()
+        }
+    }
+    @Published var selectedFile: URL? {
+        didSet {
+            addPdfCanvasElement()
+        }
+    }
 
     func addImageCanvasElement() {
         guard let image = selectedImage else {
@@ -48,36 +52,5 @@ class CanvasViewModel: ObservableObject {
 
     func addMarkUpTextBlock(markupType: MarkupTextBlock.MarkupType) {
         canvas.addElement(MarkupTextBlock(markupType: markupType))
-    }
-}
-
-// MARK: Sheets
-extension CanvasViewModel {
-    func displayCamera() {
-        activeSheet = .camera
-        lastActiveSheet = .camera
-    }
-
-    func displayPhotoGallery() {
-        activeSheet = .photoGallery
-        lastActiveSheet = .photoGallery
-    }
-
-    func displayPdfPicker() {
-        activeSheet = .pdfPicker
-        lastActiveSheet = .pdfPicker
-    }
-
-    func handleSheetDismiss() {
-        switch lastActiveSheet {
-        case .camera:
-            addImageCanvasElement()
-        case .photoGallery:
-            addImageCanvasElement()
-        case .pdfPicker:
-            addPdfCanvasElement()
-        default:
-            assert(false, "When `handleSheetDismiss` is called, `lastActiveSheet` should not be `nil`.")
-        }
     }
 }

--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
@@ -23,6 +23,16 @@ class CanvasViewModel: ObservableObject {
         selectedImage = nil
     }
 
+    func addPdfCanvasElement() {
+        // TODO: Remove temporary URL for testing.
+        guard let url = URL(string: "https://www.cs.cmu.edu/~avrim/451f11/lectures/lect1004.pdf") else {
+            return
+        }
+
+        let pdfCanvasElement = PDFCanvasElement(url: url)
+        canvas.addElement(pdfCanvasElement)
+    }
+
     func addTextBlock() {
         canvas.addElement(TextBlock())
     }

--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
@@ -25,13 +25,15 @@ class CanvasViewModel: ObservableObject {
     }
 
     func addPdfCanvasElement() {
-        // TODO: Remove temporary URL for testing.
-        guard let url = URL(string: "https://www.cs.cmu.edu/~avrim/451f11/lectures/lect1004.pdf") else {
+        guard let file = selectedFile else {
             return
         }
 
-        let pdfCanvasElement = PDFCanvasElement(url: url)
+        let pdfCanvasElement = PDFCanvasElement(file: file)
         canvas.addElement(pdfCanvasElement)
+
+        // Reset the selected file.
+        selectedFile = nil
     }
 
     func addTextBlock() {

--- a/Dynavity/Dynavity/view-model/canvas/elements/PDFCanvasElementViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/elements/PDFCanvasElementViewModel.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+class PDFCanvasElementViewModel: ObservableObject {
+    @Published var pdfCanvasElement: PDFCanvasElement
+
+    init(pdfCanvasElement: PDFCanvasElement) {
+        self.pdfCanvasElement = pdfCanvasElement
+    }
+}

--- a/Dynavity/Dynavity/view/CanvasElementMapView.swift
+++ b/Dynavity/Dynavity/view/CanvasElementMapView.swift
@@ -19,7 +19,7 @@ struct CanvasElementMapView: View {
                     case let imageCanvasElement as ImageCanvasElement:
                         ImageCanvasElementView(imageCanvasElement: imageCanvasElement)
                     case let pdfCanvasElement as PDFCanvasElement:
-                        PDFCanvasElementView(url: pdfCanvasElement.url)
+                        PDFCanvasElementView(pdfCanvasElement: pdfCanvasElement)
                     case let textBlock as TextBlock:
                         TextBlockView(textBlock: textBlock)
                     case let markupTextBlock as MarkupTextBlock:

--- a/Dynavity/Dynavity/view/CanvasElementMapView.swift
+++ b/Dynavity/Dynavity/view/CanvasElementMapView.swift
@@ -19,7 +19,7 @@ struct CanvasElementMapView: View {
                     case let imageCanvasElement as ImageCanvasElement:
                         ImageCanvasElementView(imageCanvasElement: imageCanvasElement)
                     case let pdfCanvasElement as PDFCanvasElement:
-                        PDFKitView(url: pdfCanvasElement.url)
+                        PDFCanvasElementView(url: pdfCanvasElement.url)
                     case let textBlock as TextBlock:
                         TextBlockView(textBlock: textBlock)
                     case let markupTextBlock as MarkupTextBlock:

--- a/Dynavity/Dynavity/view/CanvasElementMapView.swift
+++ b/Dynavity/Dynavity/view/CanvasElementMapView.swift
@@ -18,6 +18,8 @@ struct CanvasElementMapView: View {
                     switch element {
                     case let imageCanvasElement as ImageCanvasElement:
                         ImageCanvasElementView(imageCanvasElement: imageCanvasElement)
+                    case let pdfCanvasElement as PDFCanvasElement:
+                        PDFKitView(url: pdfCanvasElement.url)
                     case let textBlock as TextBlock:
                         TextBlockView(textBlock: textBlock)
                     case let markupTextBlock as MarkupTextBlock:

--- a/Dynavity/Dynavity/view/DocumentPickerView.swift
+++ b/Dynavity/Dynavity/view/DocumentPickerView.swift
@@ -4,7 +4,7 @@ import UniformTypeIdentifiers
 struct DocumentPickerView: UIViewControllerRepresentable {
     typealias UIViewControllerType = UIDocumentPickerViewController
 
-    @Binding var selectedFile: URL?
+    let onFileSelected: (URL) -> Void
     let contentTypes: [UTType]
     @Environment(\.presentationMode) private var presentationMode
 
@@ -39,7 +39,7 @@ struct DocumentPickerView: UIViewControllerRepresentable {
                 return
             }
 
-            parent.selectedFile = file
+            parent.onFileSelected(file)
             parent.presentationMode.wrappedValue.dismiss()
         }
     }

--- a/Dynavity/Dynavity/view/DocumentPickerView.swift
+++ b/Dynavity/Dynavity/view/DocumentPickerView.swift
@@ -4,7 +4,7 @@ import UniformTypeIdentifiers
 struct DocumentPickerView: UIViewControllerRepresentable {
     typealias UIViewControllerType = UIDocumentPickerViewController
 
-    @State private var url: URL?
+    @Binding var selectedFile: URL?
     let contentTypes: [UTType]
     @Environment(\.presentationMode) private var presentationMode
 
@@ -33,7 +33,7 @@ struct DocumentPickerView: UIViewControllerRepresentable {
             _ picker: UIViewControllerType,
             didPickDocumentsAt urls: [URL]
         ) {
-            parent.url = urls[0]
+            parent.selectedFile = urls[0]
             parent.presentationMode.wrappedValue.dismiss()
         }
     }

--- a/Dynavity/Dynavity/view/DocumentPickerView.swift
+++ b/Dynavity/Dynavity/view/DocumentPickerView.swift
@@ -10,6 +10,7 @@ struct DocumentPickerView: UIViewControllerRepresentable {
 
     func makeUIViewController(context: Context) -> UIViewControllerType {
         let documentPicker = UIViewControllerType(forOpeningContentTypes: contentTypes, asCopy: true)
+        documentPicker.allowsMultipleSelection = false
         return documentPicker
     }
 

--- a/Dynavity/Dynavity/view/DocumentPickerView.swift
+++ b/Dynavity/Dynavity/view/DocumentPickerView.swift
@@ -11,6 +11,7 @@ struct DocumentPickerView: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewControllerType {
         let documentPicker = UIViewControllerType(forOpeningContentTypes: contentTypes, asCopy: true)
         documentPicker.allowsMultipleSelection = false
+        documentPicker.delegate = context.coordinator
         return documentPicker
     }
 
@@ -30,7 +31,7 @@ struct DocumentPickerView: UIViewControllerRepresentable {
             self.parent = parent
         }
 
-        func documentPickerController(
+        func documentPicker(
             _ picker: UIViewControllerType,
             didPickDocumentsAt urls: [URL]
         ) {

--- a/Dynavity/Dynavity/view/DocumentPickerView.swift
+++ b/Dynavity/Dynavity/view/DocumentPickerView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct DocumentPickerView: UIViewControllerRepresentable {
+    typealias UIViewControllerType = UIDocumentPickerViewController
+
+    @State private var url: URL?
+    let contentTypes: [UTType]
+    @Environment(\.presentationMode) private var presentationMode
+
+    func makeUIViewController(context: Context) -> UIViewControllerType {
+        let documentPicker = UIViewControllerType(forOpeningContentTypes: contentTypes, asCopy: true)
+        return documentPicker
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {
+        // Do nothing.
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    /// Acts as a bridge between the UIDocumentPickerController's delegate and SwiftUI.
+    final class Coordinator: NSObject, UIDocumentPickerDelegate, UINavigationControllerDelegate {
+        let parent: DocumentPickerView
+
+        init(_ parent: DocumentPickerView) {
+            self.parent = parent
+        }
+
+        func documentPickerController(
+            _ picker: UIViewControllerType,
+            didPickDocumentsAt urls: [URL]
+        ) {
+            parent.url = urls[0]
+            parent.presentationMode.wrappedValue.dismiss()
+        }
+    }
+}

--- a/Dynavity/Dynavity/view/DocumentPickerView.swift
+++ b/Dynavity/Dynavity/view/DocumentPickerView.swift
@@ -35,7 +35,11 @@ struct DocumentPickerView: UIViewControllerRepresentable {
             _ picker: UIViewControllerType,
             didPickDocumentsAt urls: [URL]
         ) {
-            parent.selectedFile = urls[0]
+            guard let file = urls.first else {
+                return
+            }
+
+            parent.selectedFile = file
             parent.presentationMode.wrappedValue.dismiss()
         }
     }

--- a/Dynavity/Dynavity/view/ImagePickerView.swift
+++ b/Dynavity/Dynavity/view/ImagePickerView.swift
@@ -4,17 +4,17 @@ struct ImagePickerView: UIViewControllerRepresentable {
     typealias UIViewControllerType = UIImagePickerController
 
     @Binding var selectedImage: UIImage?
-    var sourceType: UIImagePickerController.SourceType
+    var sourceType: UIViewControllerType.SourceType
     @Environment(\.presentationMode) private var presentationMode
 
-    func makeUIViewController(context: Context) -> UIImagePickerController {
-        let imagePicker = UIImagePickerController()
+    func makeUIViewController(context: Context) -> UIViewControllerType {
+        let imagePicker = UIViewControllerType()
         imagePicker.sourceType = sourceType
         imagePicker.delegate = context.coordinator
         return imagePicker
     }
 
-    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {
         // Do nothing.
     }
 
@@ -31,8 +31,8 @@ struct ImagePickerView: UIViewControllerRepresentable {
         }
 
         func imagePickerController(
-            _ picker: UIImagePickerController,
-            didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+            _ picker: UIViewControllerType,
+            didFinishPickingMediaWithInfo info: [UIViewControllerType.InfoKey: Any]
         ) {
             if let image = info[.originalImage] as? UIImage {
                 parent.selectedImage = image

--- a/Dynavity/Dynavity/view/ImagePickerView.swift
+++ b/Dynavity/Dynavity/view/ImagePickerView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct ImagePickerView: UIViewControllerRepresentable {
     typealias UIViewControllerType = UIImagePickerController
 
-    @Binding var selectedImage: UIImage?
+    let onImageSelected: (UIImage) -> Void
     var sourceType: UIViewControllerType.SourceType
     @Environment(\.presentationMode) private var presentationMode
 
@@ -38,7 +38,7 @@ struct ImagePickerView: UIViewControllerRepresentable {
                 return
             }
 
-            parent.selectedImage = image
+            parent.onImageSelected(image)
             parent.presentationMode.wrappedValue.dismiss()
         }
     }

--- a/Dynavity/Dynavity/view/ImagePickerView.swift
+++ b/Dynavity/Dynavity/view/ImagePickerView.swift
@@ -34,10 +34,11 @@ struct ImagePickerView: UIViewControllerRepresentable {
             _ picker: UIViewControllerType,
             didFinishPickingMediaWithInfo info: [UIViewControllerType.InfoKey: Any]
         ) {
-            if let image = info[.originalImage] as? UIImage {
-                parent.selectedImage = image
+            guard let image = info[.originalImage] as? UIImage else {
+                return
             }
 
+            parent.selectedImage = image
             parent.presentationMode.wrappedValue.dismiss()
         }
     }

--- a/Dynavity/Dynavity/view/PDFKitView.swift
+++ b/Dynavity/Dynavity/view/PDFKitView.swift
@@ -1,0 +1,19 @@
+import PDFKit
+import SwiftUI
+
+struct PDFKitView: UIViewRepresentable {
+    typealias UIViewType = PDFView
+
+    let url: URL
+
+    func makeUIView(context: Context) -> UIViewType {
+        let pdfView = PDFView()
+        pdfView.document = PDFDocument(url: url)
+        pdfView.autoScales = true
+        return pdfView
+    }
+
+    func updateUIView(_ uiView: UIViewType, context: Context) {
+        // Do nothing.
+    }
+}

--- a/Dynavity/Dynavity/view/ToolbarView.swift
+++ b/Dynavity/Dynavity/view/ToolbarView.swift
@@ -88,11 +88,11 @@ struct ToolbarView: View {
         .sheet(item: $activeSheet) { item in
             switch item {
             case .camera:
-                ImagePickerView(selectedImage: $viewModel.selectedImage, sourceType: .camera)
+                ImagePickerView(onImageSelected: viewModel.addImageCanvasElement, sourceType: .camera)
             case .photoGallery:
-                ImagePickerView(selectedImage: $viewModel.selectedImage, sourceType: .photoLibrary)
+                ImagePickerView(onImageSelected: viewModel.addImageCanvasElement, sourceType: .photoLibrary)
             case .pdfPicker:
-                DocumentPickerView(selectedFile: $viewModel.selectedFile, contentTypes: [.pdf])
+                DocumentPickerView(onFileSelected: viewModel.addPdfCanvasElement, contentTypes: [.pdf])
             }
         }
         // Force the toolbar to be drawn over everything else.

--- a/Dynavity/Dynavity/view/ToolbarView.swift
+++ b/Dynavity/Dynavity/view/ToolbarView.swift
@@ -30,7 +30,7 @@ struct ToolbarView: View {
                 Label("Photo Gallery", systemImage: "photo")
             }
             Button(action: {
-                // TODO: Implement PDF import functionality.
+                viewModel.addPdfCanvasElement()
             }) {
                 Label("PDF", systemImage: "doc.text")
             }

--- a/Dynavity/Dynavity/view/ToolbarView.swift
+++ b/Dynavity/Dynavity/view/ToolbarView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct ToolbarView: View {
-    enum ActiveSheet: Identifiable {
+    private enum ActiveSheet: Identifiable {
         case camera
         case photoGallery
         case pdfPicker
@@ -15,22 +15,23 @@ struct ToolbarView: View {
     private let padding: CGFloat = 10.0
 
     @ObservedObject var viewModel: CanvasViewModel
+    @State private var activeSheet: ActiveSheet?
     @Binding var shouldShowSideMenu: Bool
 
     private var addButton: some View {
         Menu {
             Button(action: {
-                viewModel.displayCamera()
+                activeSheet = .camera
             }) {
                 Label("Camera", systemImage: "camera")
             }
             Button(action: {
-                viewModel.displayPhotoGallery()
+                activeSheet = .photoGallery
             }) {
                 Label("Photo Gallery", systemImage: "photo")
             }
             Button(action: {
-                viewModel.displayPdfPicker()
+                activeSheet = .pdfPicker
             }) {
                 Label("PDF", systemImage: "doc.text")
             }
@@ -84,7 +85,7 @@ struct ToolbarView: View {
             Color(UIColor.systemGray6)
                 .edgesIgnoringSafeArea(.top)
         )
-        .sheet(item: $viewModel.activeSheet, onDismiss: viewModel.handleSheetDismiss) { item in
+        .sheet(item: $activeSheet) { item in
             switch item {
             case .camera:
                 ImagePickerView(selectedImage: $viewModel.selectedImage, sourceType: .camera)

--- a/Dynavity/Dynavity/view/ToolbarView.swift
+++ b/Dynavity/Dynavity/view/ToolbarView.swift
@@ -4,6 +4,7 @@ struct ToolbarView: View {
     private enum ActiveSheet: Identifiable {
         case camera
         case photoGallery
+        case pdfPicker
 
         var id: Int {
             hashValue
@@ -30,7 +31,7 @@ struct ToolbarView: View {
                 Label("Photo Gallery", systemImage: "photo")
             }
             Button(action: {
-                viewModel.addPdfCanvasElement()
+                activeSheet = .pdfPicker
             }) {
                 Label("PDF", systemImage: "doc.text")
             }
@@ -90,6 +91,8 @@ struct ToolbarView: View {
                 ImagePickerView(selectedImage: $viewModel.selectedImage, sourceType: .camera)
             case .photoGallery:
                 ImagePickerView(selectedImage: $viewModel.selectedImage, sourceType: .photoLibrary)
+            case .pdfPicker:
+                DocumentPickerView(selectedFile: $viewModel.selectedFile, contentTypes: [.pdf])
             }
         }
         // Force the toolbar to be drawn over everything else.

--- a/Dynavity/Dynavity/view/ToolbarView.swift
+++ b/Dynavity/Dynavity/view/ToolbarView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct ToolbarView: View {
-    private enum ActiveSheet: Identifiable {
+    enum ActiveSheet: Identifiable {
         case camera
         case photoGallery
         case pdfPicker
@@ -15,23 +15,22 @@ struct ToolbarView: View {
     private let padding: CGFloat = 10.0
 
     @ObservedObject var viewModel: CanvasViewModel
-    @State private var activeSheet: ActiveSheet?
     @Binding var shouldShowSideMenu: Bool
 
     private var addButton: some View {
         Menu {
             Button(action: {
-                activeSheet = .camera
+                viewModel.displayCamera()
             }) {
                 Label("Camera", systemImage: "camera")
             }
             Button(action: {
-                activeSheet = .photoGallery
+                viewModel.displayPhotoGallery()
             }) {
                 Label("Photo Gallery", systemImage: "photo")
             }
             Button(action: {
-                activeSheet = .pdfPicker
+                viewModel.displayPdfPicker()
             }) {
                 Label("PDF", systemImage: "doc.text")
             }
@@ -85,7 +84,7 @@ struct ToolbarView: View {
             Color(UIColor.systemGray6)
                 .edgesIgnoringSafeArea(.top)
         )
-        .sheet(item: $activeSheet, onDismiss: viewModel.addImageCanvasElement) { item in
+        .sheet(item: $viewModel.activeSheet, onDismiss: viewModel.handleSheetDismiss) { item in
             switch item {
             case .camera:
                 ImagePickerView(selectedImage: $viewModel.selectedImage, sourceType: .camera)

--- a/Dynavity/Dynavity/view/canvas/elements/PDFCanvasElementView.swift
+++ b/Dynavity/Dynavity/view/canvas/elements/PDFCanvasElementView.swift
@@ -1,7 +1,7 @@
 import PDFKit
 import SwiftUI
 
-struct PDFKitView: UIViewRepresentable {
+struct PDFCanvasElementView: UIViewRepresentable {
     typealias UIViewType = PDFView
 
     let url: URL

--- a/Dynavity/Dynavity/view/canvas/elements/PDFCanvasElementView.swift
+++ b/Dynavity/Dynavity/view/canvas/elements/PDFCanvasElementView.swift
@@ -4,11 +4,15 @@ import SwiftUI
 struct PDFCanvasElementView: UIViewRepresentable {
     typealias UIViewType = PDFView
 
-    let url: URL
+    @ObservedObject var viewModel: PDFCanvasElementViewModel
+
+    init(pdfCanvasElement: PDFCanvasElement) {
+        self.viewModel = PDFCanvasElementViewModel(pdfCanvasElement: pdfCanvasElement)
+    }
 
     func makeUIView(context: Context) -> UIViewType {
         let pdfView = PDFView()
-        pdfView.document = PDFDocument(url: url)
+        pdfView.document = PDFDocument(url: viewModel.pdfCanvasElement.url)
         pdfView.autoScales = true
         return pdfView
     }

--- a/Dynavity/Dynavity/view/canvas/elements/PDFCanvasElementView.swift
+++ b/Dynavity/Dynavity/view/canvas/elements/PDFCanvasElementView.swift
@@ -12,7 +12,7 @@ struct PDFCanvasElementView: UIViewRepresentable {
 
     func makeUIView(context: Context) -> UIViewType {
         let pdfView = PDFView()
-        pdfView.document = PDFDocument(url: viewModel.pdfCanvasElement.url)
+        pdfView.document = PDFDocument(url: viewModel.pdfCanvasElement.file)
         pdfView.autoScales = true
         return pdfView
     }


### PR DESCRIPTION
## Features

* Add PDF canvas elements.
  * PDF files are imported via a document picker.
  * PDF files are displayed using `PDFKit`'s `PDFView`.

## Additional Details

* Update `info.plist` with `NSDocumentsFolderUsageDescription` so that the application can access these resources.
* Add `canvasCenter` to `CGPoint` to address the change in origin in #12.

## Design Trade-offs

### Handling different behaviours upon dismissing the sheet

Previously, we decided to use an enum to represent the currently displayed sheet. See https://github.com/Dynavity/dynavity/pull/9#discussion_r595957187 for more information. However, we run into the issue where each sheet can only have a single `onDismiss` action. With the addition of PDF canvas elements, we now need to call either `addImageCanvasElement` or `addPdfCanvasElement` in `CanvasViewModel`, depending on which sheet was last displayed.

The first solution I tried was to create another function in `CanvasViewModel` that called either one of the above functions by checking the value of `activeSheet`. Unfortunately, this is not possible as `activeSheet` would have already been set to `nil` by the time `onDismiss` is called.

Subsequently, I moved the `activeSheet` variable out of `ToolbarView` and into `CanvasViewModel`. There, I added setter functions for `activeSheet` (i.e., `displayCamera`, `displayPhotoGallery`, `displayPdfPicker`). In addition, I also separately kept a private variable `lastActiveSheet`. This variable was set along with `activeSheet` in each of the setter functions. By doing so, we are able to know what the value of `activeSheet` was before the sheet was dismissed. This solution was not ideal for the following reasons:
1. Unable to enforce `private(set)` on the `activeSheet` variable in `CanvasViewModel`. This is because the sheet itself accesses `activeSheet` through a two-way binding and thus requires write access. Unfortunately, this means that we cannot enforce changing the value of `activeSheet` only through out setter functions.
1. The use of the `activeSheet` and `lastActiveSheet` variables is not very elegant as the states of both variables have to be constantly kept synchronised. Future extensions to the code can very easily break the invariants we have set out, making the code brittle.
1. I discovered a separate issue that renders this solution unfeasible anyway. See below for a detailed explanation of the issue.

### Delay in document picker setting the URL of the picked file

Unlike the image picker, the document picker has a slight delay in updating the `selectedFile` binding. With the previous solution discussed above in place, it was found that `addPdfCanvasElement` would trigger before the `selectedFile` binding was updated by the document picker. This might be due to the file picker having to create a copy of the file. However, this also raises the possibility that the image picker might suffer from this behaviour too (if the selected image is huge).

Clearly, some form of synchronisation is needed to solve this issue. Potential solutions include busy waiting, or setting a fixed delay before the functions to add the canvas elements are called. The former is undesirable as we will needlessly use up CPU cycles (as well as fail CS3217 since Prof Wai Kay will get an aneurysm if he sees us do that), while the latter not only makes the application feel less responsive, it also does not guarantee that the bindings will be updated before the functions are called.

Instead, we have a very elegant solution, which is to use the `didSet` property observer on our `selectedImage` and `selectedFile` bindings.

**Update:** @sebastiantoh correctly identified that `didSet` will trigger multiple times which is not ideal. After further consideration, I realised that I can just pass `addImageCanvasElement` and `addPdfCanvasElement` as callback functions to the image picker and document picker respectively. Not only does this solve the issue of the order of execution being unsynchronised, it also reduces coupling between `CanvasViewModel` and the respective pickers as we no longer need to maintain the `selectedImage` and `selectedFile` variables.

### Issues

When adding PDFs, they follow the dimensions of the last added canvas element. This should be resolved once the logic to place items on the canvas based off the current view of the canvas is added.