### PR TITLE
Create and delete canvas

### DIFF
--- a/Dynavity/Dynavity/view/CanvasSelectionView.swift
+++ b/Dynavity/Dynavity/view/CanvasSelectionView.swift
@@ -78,7 +78,7 @@ struct CanvasSelectionView: View {
                 }) {
                     Image(systemName: "trash")
                 }.disabled(noCanvasSelected)
-                
+
                 SearchBar(text: $searchQuery)
             } else {
                 Button("Edit") {

--- a/Dynavity/Dynavity/view/CanvasSelectionView.swift
+++ b/Dynavity/Dynavity/view/CanvasSelectionView.swift
@@ -26,15 +26,16 @@ struct CanvasSelectionView: View {
         }
     }
 
+    var noCanvasSelected: Bool {
+        canvases.allSatisfy {
+            !$0.isSelected
+        }
+    }
+
     var body: some View {
         NavigationView {
             VStack {
-                HStack {
-                    Button(isEditing ? "Done" : "Edit") {
-                        toggleEditMode()
-                    }
-                    SearchBar(text: $searchQuery)
-                }
+                editButtonGroup
                 .padding()
                 ScrollView {
                     canvasesGrid
@@ -63,6 +64,28 @@ struct CanvasSelectionView: View {
             }
         }
         .padding(.horizontal)
+    }
+
+    var editButtonGroup: some View {
+        HStack {
+            if isEditing {
+                Button("Done") {
+                    toggleEditMode()
+                }
+                Button(action: {
+                    deleteSelectedCanvases()
+                    toggleEditMode()
+                }) {
+                    Image(systemName: "trash")
+                }.disabled(noCanvasSelected)
+                SearchBar(text: $searchQuery)
+            } else {
+                Button("Edit") {
+                    toggleEditMode()
+                }
+                SearchBar(text: $searchQuery)
+            }
+        }
     }
 }
 
@@ -94,6 +117,15 @@ extension CanvasSelectionView {
     func clearSelectedCanvases() {
         canvases = canvases.map {
             CanvasSelectionView.CanvasDetail(title: $0.title, isSelected: false)
+        }
+    }
+
+    func deleteSelectedCanvases() {
+        canvases = canvases.compactMap {
+            if $0.isSelected {
+                return nil
+            }
+            return CanvasSelectionView.CanvasDetail(title: $0.title, isSelected: false)
         }
     }
 }

--- a/Dynavity/Dynavity/view/CanvasSelectionView.swift
+++ b/Dynavity/Dynavity/view/CanvasSelectionView.swift
@@ -35,7 +35,7 @@ struct CanvasSelectionView: View {
     var body: some View {
         NavigationView {
             VStack {
-                editButtonGroup
+                actionButtonGroup
                 .padding()
                 ScrollView {
                     canvasesGrid
@@ -66,7 +66,7 @@ struct CanvasSelectionView: View {
         .padding(.horizontal)
     }
 
-    var editButtonGroup: some View {
+    var actionButtonGroup: some View {
         HStack {
             if isEditing {
                 Button("Done") {
@@ -78,12 +78,19 @@ struct CanvasSelectionView: View {
                 }) {
                     Image(systemName: "trash")
                 }.disabled(noCanvasSelected)
+                
                 SearchBar(text: $searchQuery)
             } else {
                 Button("Edit") {
                     toggleEditMode()
                 }
                 SearchBar(text: $searchQuery)
+                // TODO: Implement saving the newly created canvas to state & db
+                NavigationLink(destination: MainView()
+                                .navigationBarHidden(true)
+                                .navigationBarBackButtonHidden(true)) {
+                    Image(systemName: "doc.fill.badge.plus")
+                }
             }
         }
     }

--- a/Dynavity/Dynavity/view/CanvasSelectionView.swift
+++ b/Dynavity/Dynavity/view/CanvasSelectionView.swift
@@ -6,11 +6,9 @@ struct CanvasSelectionView: View {
         var isSelected: Bool
     }
 
-    @Binding var canvases: [CanvasDetail]
+    @State var canvases: [CanvasDetail]
     @State var searchQuery: String = ""
     @State var isEditing = false
-    var toggleSelectedCanvas: (String) -> Void
-    var clearSelectedCanvases: () -> Void
 
     let columns = [
         GridItem(.flexible()),
@@ -69,12 +67,8 @@ struct CanvasSelectionView: View {
 }
 
 struct CanvasSelectionView_Previews: PreviewProvider {
-    static func toggle(input: String) {}
-    static func clear() {}
     static var previews: some View {
-        CanvasSelectionView(canvases: .constant([]),
-                            toggleSelectedCanvas: toggle,
-                            clearSelectedCanvases: clear)
+        CanvasSelectionView(canvases: [])
     }
 }
 
@@ -84,6 +78,22 @@ extension CanvasSelectionView {
 
         if !isEditing {
             clearSelectedCanvases()
+        }
+    }
+
+    func toggleSelectedCanvas(_ title: String) {
+        canvases = canvases.map {
+            if $0.title == title {
+                return CanvasSelectionView.CanvasDetail(title: $0.title,
+                                                        isSelected: !$0.isSelected)
+            }
+            return $0
+        }
+    }
+
+    func clearSelectedCanvases() {
+        canvases = canvases.map {
+            CanvasSelectionView.CanvasDetail(title: $0.title, isSelected: false)
         }
     }
 }

--- a/Dynavity/Dynavity/view/CanvasSelectionView.swift
+++ b/Dynavity/Dynavity/view/CanvasSelectionView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct CanvasSelectionView: View {
+    // TODO: Use actual canvas model instead, this is a temporary substitute
     struct CanvasDetail: Hashable {
         var title: String
         var isSelected: Bool

--- a/Dynavity/Dynavity/view/HomeView.swift
+++ b/Dynavity/Dynavity/view/HomeView.swift
@@ -2,37 +2,16 @@ import SwiftUI
 
 struct HomeView: View {
     // TODO: replace this with list of actual canvases
-    @State var canvases: [CanvasSelectionView.CanvasDetail] = (1...100)
+    var canvases: [CanvasSelectionView.CanvasDetail] = (1...100)
         .map { CanvasSelectionView.CanvasDetail(title: "Canvas \($0)", isSelected: false) }
 
     var body: some View {
-        CanvasSelectionView(canvases: $canvases,
-                            toggleSelectedCanvas: toggleSelectedCanvas,
-                            clearSelectedCanvases: clearSelectedCanvases)
+        CanvasSelectionView(canvases: canvases)
     }
 }
 
 struct HomeView_Previews: PreviewProvider {
     static var previews: some View {
         HomeView()
-    }
-}
-
-extension HomeView {
-    func toggleSelectedCanvas(title: String) {
-        canvases = canvases.map {
-            if $0.title == title {
-                return CanvasSelectionView.CanvasDetail(title: $0.title,
-                                                        isSelected: !$0.isSelected)
-
-            }
-            return $0
-        }
-    }
-
-    func clearSelectedCanvases() {
-        canvases = canvases.map {
-            CanvasSelectionView.CanvasDetail(title: $0.title, isSelected: false)
-        }
     }
 }

--- a/Dynavity/Dynavity/view/HomeView.swift
+++ b/Dynavity/Dynavity/view/HomeView.swift
@@ -2,15 +2,37 @@ import SwiftUI
 
 struct HomeView: View {
     // TODO: replace this with list of actual canvases
-    @State var canvases: [String] = (1...100).map { "Canvas \($0)" }
+    @State var canvases: [CanvasSelectionView.CanvasDetail] = (1...100)
+        .map { CanvasSelectionView.CanvasDetail(title: "Canvas \($0)", isSelected: false) }
 
     var body: some View {
-        CanvasSelectionView(canvases: $canvases)
+        CanvasSelectionView(canvases: $canvases,
+                            toggleSelectedCanvas: toggleSelectedCanvas,
+                            clearSelectedCanvases: clearSelectedCanvases)
     }
 }
 
 struct HomeView_Previews: PreviewProvider {
     static var previews: some View {
         HomeView()
+    }
+}
+
+extension HomeView {
+    func toggleSelectedCanvas(title: String) {
+        canvases = canvases.map {
+            if $0.title == title {
+                return CanvasSelectionView.CanvasDetail(title: $0.title,
+                                                        isSelected: !$0.isSelected)
+
+            }
+            return $0
+        }
+    }
+
+    func clearSelectedCanvases() {
+        canvases = canvases.map {
+            CanvasSelectionView.CanvasDetail(title: $0.title, isSelected: false)
+        }
     }
 }

--- a/Dynavity/Dynavity/view/canvas/CanvasThumbnailView.swift
+++ b/Dynavity/Dynavity/view/canvas/CanvasThumbnailView.swift
@@ -5,20 +5,12 @@ struct CanvasThumbnailView: View {
     var isSelected: Bool
     var body: some View {
         VStack {
-            if isSelected {
-                // TODO: replace this with canvas thumbnail
-                Image(systemName: "doc")
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(width: 70)
-                    .overlay(checkSymbol)
-            } else {
-                // TODO: replace this with canvas thumbnail
-                Image(systemName: "doc")
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(width: 70)
-            }
+            // TODO: replace this with canvas thumbnail
+            Image(systemName: "doc")
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: 70)
+                .overlay(isSelected ? checkSymbol : nil)
             Text(canvasName)
         }
     }

--- a/Dynavity/Dynavity/view/canvas/CanvasThumbnailView.swift
+++ b/Dynavity/Dynavity/view/canvas/CanvasThumbnailView.swift
@@ -2,20 +2,36 @@ import SwiftUI
 
 struct CanvasThumbnailView: View {
     var canvasName: String
+    var isSelected: Bool
     var body: some View {
         VStack {
-            // TODO: replace this with canvas thumbnail
-            Image(systemName: "doc")
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(width: 70)
+            if isSelected {
+                // TODO: replace this with canvas thumbnail
+                Image(systemName: "doc")
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 70)
+                    .overlay(checkSymbol)
+            } else {
+                // TODO: replace this with canvas thumbnail
+                Image(systemName: "doc")
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 70)
+            }
             Text(canvasName)
         }
+    }
+
+    var checkSymbol: some View {
+        Image(systemName: "checkmark.circle")
+            .scaleEffect(1.5)
+            .foregroundColor(Color.blue)
     }
 }
 
 struct CanvasThumbnailView_Previews: PreviewProvider {
     static var previews: some View {
-        CanvasThumbnailView(canvasName: "")
+        CanvasThumbnailView(canvasName: "", isSelected: false)
     }
 }

--- a/Dynavity/Dynavity/view/canvas/CanvasView.swift
+++ b/Dynavity/Dynavity/view/canvas/CanvasView.swift
@@ -12,6 +12,27 @@ struct CanvasView: View {
     init(viewModel: CanvasViewModel) {
         self.viewModel = viewModel
     }
+
+    final class Coordinator: NSObject, PKCanvasViewDelegate {
+        var canvasView: CanvasView
+        let onChange: () -> Void
+
+        init(canvasView: CanvasView,
+             onChange: @escaping () -> Void) {
+            self.canvasView = canvasView
+            self.onChange = onChange
+        }
+
+        func canvasViewDrawingDidChange(_ canvasView: PKCanvasView) {
+            if !canvasView.drawing.bounds.isEmpty {
+                onChange()
+            }
+        }
+
+        func scrollViewDidZoom(_ scrollView: UIScrollView) {
+            canvasView.didZoom(to: scrollView.zoomScale)
+        }
+    }
 }
 
 struct CanvasView_Previews: PreviewProvider {
@@ -86,28 +107,5 @@ extension CanvasView: UIViewRepresentable {
     func makeCoordinator() -> Coordinator {
         Coordinator(canvasView: self,
                     onChange: saveAnnotationToModel)
-    }
-}
-
-class Coordinator: NSObject {
-    var canvasView: CanvasView
-    let onChange: () -> Void
-
-    init(canvasView: CanvasView,
-         onChange: @escaping () -> Void) {
-        self.canvasView = canvasView
-        self.onChange = onChange
-    }
-}
-
-extension Coordinator: PKCanvasViewDelegate {
-    func canvasViewDrawingDidChange(_ canvasView: PKCanvasView) {
-        if !canvasView.drawing.bounds.isEmpty {
-            onChange()
-        }
-    }
-
-    func scrollViewDidZoom(_ scrollView: UIScrollView) {
-        canvasView.didZoom(to: scrollView.zoomScale)
     }
 }


### PR DESCRIPTION
## Changes Made
1. Add new canvas
    - This is only a UI implementation, the canvas that is navigated to is not actually added to the `canvases` state. This is to be done after the naming of canvases. Similar to Notability, where new notes are only saved if it is changed (with annotations or note elements) or renamed.
2. Delete existing canvases
    - This allows multi-select delete from `canvases` state using an Edit mode in the `CanvasSelectionView`

## Note
- The state of `canvases` is moved from `HomeView` to `CanvasSelectionView`. This is to reduce the number of callback functions needed to mutate the state of `canvases` from the `CanvasSelectionView`.

![image](https://user-images.githubusercontent.com/24553546/111866020-5abee080-89a5-11eb-8db4-c3d30090b90b.png)
