### PR TITLE
Dismissing sidemenu gesture and Adding of LaTeX markup text blocks

### DIFF
--- a/Dynavity/Dynavity/view/MainView.swift
+++ b/Dynavity/Dynavity/view/MainView.swift
@@ -26,9 +26,8 @@ struct MainView: View {
                         .transition(.move(edge: .trailing))
                         // Force the side menu to be drawn over everything else.
                         .zIndex(.infinity)
-                        .gesture(dismissSideMenuDragGesture)
                 }
-            }
+            }.gesture(shouldShowMenu ? dismissSideMenuDragGesture : nil)
         }
     }
 

--- a/Dynavity/Dynavity/view/ToolbarView.swift
+++ b/Dynavity/Dynavity/view/ToolbarView.swift
@@ -51,10 +51,14 @@ struct ToolbarView: View {
                 Label("Code", systemImage: "chevron.left.slash.chevron.right")
             }
             Button(action: {
-                // TODO: Update this function to take in a markupType based on user input
                 viewModel.addMarkUpTextBlock(markupType: .markdown)
             }) {
                 Label("Markup", systemImage: "text.badge.star")
+            }
+            Button(action: {
+                viewModel.addMarkUpTextBlock(markupType: .latex)
+            }) {
+                Label("LaTeX", systemImage: "doc.richtext")
             }
         }
         label: {

--- a/Dynavity/Dynavity/view/ToolbarView.swift
+++ b/Dynavity/Dynavity/view/ToolbarView.swift
@@ -70,7 +70,6 @@ struct ToolbarView: View {
                 Label("LaTeX", systemImage: "doc.richtext")
             }
         }
-
     }
 
     private var sideMenuButton: some View {

--- a/Dynavity/Dynavity/view/ToolbarView.swift
+++ b/Dynavity/Dynavity/view/ToolbarView.swift
@@ -50,6 +50,15 @@ struct ToolbarView: View {
             }) {
                 Label("Code", systemImage: "chevron.left.slash.chevron.right")
             }
+            markupTextBlockButtons
+        }
+        label: {
+            Label("Add", systemImage: "plus")
+        }
+    }
+
+    private var markupTextBlockButtons: some View {
+        Group {
             Button(action: {
                 viewModel.addMarkUpTextBlock(markupType: .markdown)
             }) {
@@ -61,9 +70,7 @@ struct ToolbarView: View {
                 Label("LaTeX", systemImage: "doc.richtext")
             }
         }
-        label: {
-            Label("Add", systemImage: "plus")
-        }
+
     }
 
     private var sideMenuButton: some View {


### PR DESCRIPTION
Changes:
- Allow dismissing side menu by swiping outside of SideMenu (while not interfering with annotations)
- Allow adding of LaTeX markup text block (done by introducing a new button)