### PR TITLE
Fix text persistence issue

### DIFF
--- a/Dynavity/Dynavity/view/CanvasSelectionView.swift
+++ b/Dynavity/Dynavity/view/CanvasSelectionView.swift
@@ -8,8 +8,8 @@ struct CanvasSelectionView: View {
     }
 
     @State var canvases: [CanvasDetail]
-    @State var searchQuery: String = ""
-    @State var isEditing = false
+    @State private var searchQuery: String = ""
+    @State private var isEditing = false
 
     let columns = [
         GridItem(.flexible()),

--- a/Dynavity/Dynavity/view/MainView.swift
+++ b/Dynavity/Dynavity/view/MainView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct MainView: View {
     @ObservedObject private var canvasViewModel = CanvasViewModel()
-    @State var shouldShowMenu = false
+    @State private var shouldShowMenu = false
 
     var body: some View {
         GeometryReader { geometry in

--- a/Dynavity/Dynavity/view/canvas/AnnotationCanvasView.swift
+++ b/Dynavity/Dynavity/view/canvas/AnnotationCanvasView.swift
@@ -3,8 +3,8 @@ import PencilKit
 
 struct AnnotationCanvasView: View {
     @ObservedObject var viewModel: CanvasViewModel
-    @State var annotationCanvasView = PKCanvasWrapperView()
-    @State var toolPicker = PKToolPicker()
+    @State private var annotationCanvasView = PKCanvasWrapperView()
+    @State private var toolPicker = PKToolPicker()
 
     init(viewModel: CanvasViewModel) {
         self.viewModel = viewModel

--- a/Dynavity/Dynavity/view/canvas/elements/ImageCanvasElementView.swift
+++ b/Dynavity/Dynavity/view/canvas/elements/ImageCanvasElementView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct ImageCanvasElementView: View {
-    @StateObject var viewModel: ImageCanvasElementViewModel
+    @StateObject private var viewModel: ImageCanvasElementViewModel
 
     init(imageCanvasElement: ImageCanvasElement) {
         self._viewModel = StateObject(wrappedValue: ImageCanvasElementViewModel(imageCanvasElement: imageCanvasElement))

--- a/Dynavity/Dynavity/view/canvas/elements/ImageCanvasElementView.swift
+++ b/Dynavity/Dynavity/view/canvas/elements/ImageCanvasElementView.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 
 struct ImageCanvasElementView: View {
-    @ObservedObject var viewModel: ImageCanvasElementViewModel
+    @StateObject var viewModel: ImageCanvasElementViewModel
 
     init(imageCanvasElement: ImageCanvasElement) {
-        self.viewModel = ImageCanvasElementViewModel(imageCanvasElement: imageCanvasElement)
+        self._viewModel = StateObject(wrappedValue: ImageCanvasElementViewModel(imageCanvasElement: imageCanvasElement))
     }
 
     var body: some View {

--- a/Dynavity/Dynavity/view/canvas/elements/MarkupTextBlockView.swift
+++ b/Dynavity/Dynavity/view/canvas/elements/MarkupTextBlockView.swift
@@ -6,7 +6,7 @@ struct MarkupTextBlockView: View {
     // TODO: This is set to "selected" for now.
     // The parent view containing this view should probably implement the logic for view selection.
     // Purpose of having this state is so that when the view is not selected, the text editor will not show
-    @State var isViewSelected = true
+    @State private var isViewSelected = true
 
     init(markupTextBlock: MarkupTextBlock) {
         self._viewModel = StateObject(wrappedValue:

--- a/Dynavity/Dynavity/view/canvas/elements/MarkupTextBlockView.swift
+++ b/Dynavity/Dynavity/view/canvas/elements/MarkupTextBlockView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct MarkupTextBlockView: View {
-    @ObservedObject var viewModel: MarkupTextBlockViewModel
+    @StateObject private var viewModel: MarkupTextBlockViewModel
 
     // TODO: This is set to "selected" for now.
     // The parent view containing this view should probably implement the logic for view selection.
@@ -9,7 +9,8 @@ struct MarkupTextBlockView: View {
     @State var isViewSelected = true
 
     init(markupTextBlock: MarkupTextBlock) {
-        self.viewModel = MarkupTextBlockViewModel(markupTextBlock: markupTextBlock)
+        self._viewModel = StateObject(wrappedValue:
+                                        MarkupTextBlockViewModel(markupTextBlock: markupTextBlock))
     }
 
     var body: some View {

--- a/Dynavity/Dynavity/view/canvas/elements/PDFCanvasElementView.swift
+++ b/Dynavity/Dynavity/view/canvas/elements/PDFCanvasElementView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct PDFCanvasElementView: UIViewRepresentable {
     typealias UIViewType = PDFView
 
-    @StateObject var viewModel: PDFCanvasElementViewModel
+    @StateObject private var viewModel: PDFCanvasElementViewModel
 
     init(pdfCanvasElement: PDFCanvasElement) {
         self._viewModel = StateObject(wrappedValue:

--- a/Dynavity/Dynavity/view/canvas/elements/PDFCanvasElementView.swift
+++ b/Dynavity/Dynavity/view/canvas/elements/PDFCanvasElementView.swift
@@ -4,10 +4,11 @@ import SwiftUI
 struct PDFCanvasElementView: UIViewRepresentable {
     typealias UIViewType = PDFView
 
-    @ObservedObject var viewModel: PDFCanvasElementViewModel
+    @StateObject var viewModel: PDFCanvasElementViewModel
 
     init(pdfCanvasElement: PDFCanvasElement) {
-        self.viewModel = PDFCanvasElementViewModel(pdfCanvasElement: pdfCanvasElement)
+        self._viewModel = StateObject(wrappedValue:
+                                        PDFCanvasElementViewModel(pdfCanvasElement: pdfCanvasElement))
     }
 
     func makeUIView(context: Context) -> UIViewType {

--- a/Dynavity/Dynavity/view/canvas/elements/TextBlockView.swift
+++ b/Dynavity/Dynavity/view/canvas/elements/TextBlockView.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 
 struct TextBlockView: View {
-    @ObservedObject var viewModel: TextBlockViewModel
+    @StateObject private var viewModel: TextBlockViewModel
 
     init(textBlock: TextBlock) {
-        self.viewModel = TextBlockViewModel(textBlock: textBlock)
+        self._viewModel = StateObject(wrappedValue: TextBlockViewModel(textBlock: textBlock))
     }
 
     var body: some View {


### PR DESCRIPTION
**This branch is based off @ianyong 's `ian/reposition-resize-rotate-delete` as I couldn't find a way to disable the annotation gestures, which is necessary for inputting text for testing**
 

# Changes
- Fix text persistence by changing `ObservedObject` to `StateObject` in the canvas element views (this is done to other element views as well, even those that do not have the text persistence issue, for correctness sake)

> A common mistake with @ObservedObjects is to declare and initialise them inside the View itself. This will lead to problems, since every time the @ObservedObject emits an update (one of its @Published properties gets updated), the view will be recreated - which will also create a new @ObservedObject, since it was initialised in the View itself. To avoid this problem, whenever you use @ObservedObject, you always have to inject it into the view. The iOS 14 @StateObject solves this issue.
> - https://stackoverflow.com/questions/61361788/state-vs-observableobject-which-and-when

- Set `@State` and `@StateObject` to private (except for those whose initialisers require knowing of these states)

Spent way too long on this by thinking that the bug was with the `ForEach` :(

@wltan You may want to try incorporating this fix into your PR as well