### PR TITLE
Increase minimum size of code snippets

### DIFF
--- a/Dynavity/Dynavity/model/CanvasElementProtocol.swift
+++ b/Dynavity/Dynavity/model/CanvasElementProtocol.swift
@@ -7,6 +7,8 @@ protocol CanvasElementProtocol {
     var width: CGFloat { get set }
     var height: CGFloat { get set }
     var rotation: Double { get set }
+    var minimumWidth: CGFloat { get }
+    var minimumHeight: CGFloat { get }
 
     mutating func move(by translation: CGSize)
     mutating func resize(by translation: CGSize)

--- a/Dynavity/Dynavity/model/canvas/elements/CodeSnippet.swift
+++ b/Dynavity/Dynavity/model/canvas/elements/CodeSnippet.swift
@@ -5,6 +5,14 @@ struct CodeSnippet: CanvasElementProtocol {
     var textBlock: TextBlock
     var language = CodeLanguage.python
 
+    var minimumWidth: CGFloat {
+        60.0
+    }
+
+    var minimumHeight: CGFloat {
+        60.0
+    }
+
     init(position: CGPoint) {
         self.textBlock = TextBlock(position: position)
         resetCodeTemplate()

--- a/Dynavity/Dynavity/view-model/canvas/elements/CodeSnippetViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/elements/CodeSnippetViewModel.swift
@@ -45,16 +45,10 @@ class CodeSnippetViewModel: ObservableObject {
 
     func listenForOutput() {
         func processTextResponse(text: String) {
-            guard let data = text.data(using: .utf8) else {
-                return
-            }
-            guard let jsonAny = try? JSONSerialization.jsonObject(with: data, options: []) else {
-                return
-            }
-            guard let jsonDict = jsonAny as? [String: String] else {
-                return
-            }
-            guard let container = jsonDict["containerId"] else {
+            guard let data = text.data(using: .utf8),
+                  let jsonAny = try? JSONSerialization.jsonObject(with: data, options: []),
+                  let jsonDict = jsonAny as? [String: String],
+                  let container = jsonDict["containerId"] else {
                 return
             }
             if let output = jsonDict["output"] {


### PR DESCRIPTION
A smaller size causes some elements (e.g. language selection) to appear outside the boundaries of the canvas.

Other changes:
- Properties `minimumWidth` and `minimumHeight` are added to the `CanvasElementProtocol` itself. Otherwise, overriding will not take place and the extension value will always be used.
- Refactored a series of guard statements to make it more compact.