### PR TITLE
Add mode for interacting with canvas elements

### DIFF
--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
@@ -11,6 +11,7 @@ class CanvasViewModel: ObservableObject {
     @Published var scaleFactor: CGFloat = 1.0
     @Published var selectedCanvasElementId: UUID?
     @Published var currentlySelectedTool: ToolbarView.SelectedAnnotationTool?
+    @Published var shouldShowAnnotationMenu = false
 
     // Reposition drag gesture
     private var dragStartLocation: CGPoint?
@@ -192,15 +193,15 @@ extension CanvasViewModel {
         currentlySelectedTool != nil
     }
 
-    func switchAnnotationTool(_ newTool: PKTool) {
+    private func switchAnnotationTool(_ newTool: PKTool) {
         annotationPalette.switchTool(newTool)
     }
 
-    func switchAnnotationWidth(_ newWidth: CGFloat) {
+    private func switchAnnotationWidth(_ newWidth: CGFloat) {
         annotationPalette.switchAnnotationWidth(newWidth)
     }
 
-    func switchAnnotationColor(_ newColor: UIColor) {
+    private func switchAnnotationColor(_ newColor: UIColor) {
         annotationPalette.switchAnnotationColor(newColor)
     }
 
@@ -227,5 +228,44 @@ extension CanvasViewModel {
         @unknown default:
             fatalError("PKInkingTool is not a pen or marker")
         }
+    }
+}
+
+// MARK: Annotation palette controls button handlers
+extension CanvasViewModel {
+    func selectPenAnnotationTool() {
+        if currentlySelectedTool == .pen {
+            shouldShowAnnotationMenu = true
+        }
+        currentlySelectedTool = .pen
+        switchAnnotationTool(getDefaultAnnotationTool(PKInkingTool.InkType.pen))
+    }
+
+    func selectMarkerAnnotationTool() {
+        if currentlySelectedTool == .marker {
+            shouldShowAnnotationMenu = true
+        }
+        currentlySelectedTool = .marker
+        switchAnnotationTool(getDefaultAnnotationTool(PKInkingTool.InkType.marker))
+    }
+
+    func selectEraserAnnotationTool() {
+        currentlySelectedTool = .eraser
+        switchAnnotationTool(PKEraserTool(.vector))
+    }
+
+    func selectLassoAnnotationTool() {
+        currentlySelectedTool = .lasso
+        switchAnnotationTool(PKLassoTool())
+    }
+
+    func selectAnnotationWidth(_ width: CGFloat) {
+        switchAnnotationWidth(width)
+        shouldShowAnnotationMenu = false
+    }
+
+    func selectAnnotationColor(_ color: UIColor) {
+        switchAnnotationColor(color)
+        shouldShowAnnotationMenu = false
     }
 }

--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
@@ -2,6 +2,14 @@ import SwiftUI
 import PencilKit
 
 class CanvasViewModel: ObservableObject {
+    enum CanvasMode {
+        case selection
+        case pen
+        case marker
+        case eraser
+        case lasso
+    }
+
     @Published var canvas = Canvas()
     @Published var annotationCanvas = AnnotationCanvas()
     @Published var annotationPalette = AnnotationPalette()
@@ -10,14 +18,7 @@ class CanvasViewModel: ObservableObject {
     @Published var canvasCenterOffsetY: CGFloat = 0.0
     @Published var scaleFactor: CGFloat = 1.0
     @Published var selectedCanvasElementId: UUID?
-    @Published var currentlySelectedTool: ToolbarView.SelectedAnnotationTool? {
-        didSet {
-            // Reset the selected canvas element if an annotation tool is selected.
-            if currentlySelectedTool != nil {
-                selectedCanvasElementId = nil
-            }
-        }
-    }
+    @Published var canvasMode: CanvasMode
     @Published var shouldShowAnnotationMenu = false
 
     // Reposition drag gesture
@@ -30,7 +31,7 @@ class CanvasViewModel: ObservableObject {
 
     init(canvasSize: CGFloat) {
         self.canvasSize = canvasSize
-        self.currentlySelectedTool = ToolbarView.SelectedAnnotationTool.pen
+        self.canvasMode = .pen
     }
 
     convenience init() {
@@ -196,10 +197,6 @@ extension CanvasViewModel {
 
 // MARK: Annotation palette controls
 extension CanvasViewModel {
-    var isAnnotationPaletteActive: Bool {
-        currentlySelectedTool != nil
-    }
-
     private func switchAnnotationTool(_ newTool: PKTool) {
         annotationPalette.switchTool(newTool)
     }
@@ -241,28 +238,28 @@ extension CanvasViewModel {
 // MARK: Annotation palette controls button handlers
 extension CanvasViewModel {
     func selectNoAnnotationTool() {
-        currentlySelectedTool = nil
+        canvasMode = .selection
     }
 
     func selectPenAnnotationTool() {
-        shouldShowAnnotationMenu = currentlySelectedTool == .pen
-        currentlySelectedTool = .pen
+        shouldShowAnnotationMenu = canvasMode == .pen
+        canvasMode = .pen
         switchAnnotationTool(getDefaultAnnotationTool(PKInkingTool.InkType.pen))
     }
 
     func selectMarkerAnnotationTool() {
-        shouldShowAnnotationMenu = currentlySelectedTool == .marker
-        currentlySelectedTool = .marker
+        shouldShowAnnotationMenu = canvasMode == .marker
+        canvasMode = .marker
         switchAnnotationTool(getDefaultAnnotationTool(PKInkingTool.InkType.marker))
     }
 
     func selectEraserAnnotationTool() {
-        currentlySelectedTool = .eraser
+        canvasMode = .eraser
         switchAnnotationTool(PKEraserTool(.vector))
     }
 
     func selectLassoAnnotationTool() {
-        currentlySelectedTool = .lasso
+        canvasMode = .lasso
         switchAnnotationTool(PKLassoTool())
     }
 

--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
@@ -18,7 +18,14 @@ class CanvasViewModel: ObservableObject {
     @Published var canvasCenterOffsetY: CGFloat = 0.0
     @Published var scaleFactor: CGFloat = 1.0
     @Published var selectedCanvasElementId: UUID?
-    @Published var canvasMode: CanvasMode
+    @Published var canvasMode: CanvasMode {
+        didSet {
+            // Reset canvas element selection on selecting some other mode.
+            if oldValue == .selection && canvasMode != oldValue {
+                selectedCanvasElementId = nil
+            }
+        }
+    }
     @Published var shouldShowAnnotationMenu = false
 
     // Reposition drag gesture
@@ -237,7 +244,7 @@ extension CanvasViewModel {
 
 // MARK: Annotation palette controls button handlers
 extension CanvasViewModel {
-    func selectNoAnnotationTool() {
+    func clearSelectedAnnotationTool() {
         canvasMode = .selection
     }
 

--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
@@ -10,6 +10,7 @@ class CanvasViewModel: ObservableObject {
     @Published var canvasCenterOffsetY: CGFloat = 0.0
     @Published var scaleFactor: CGFloat = 1.0
     @Published var selectedCanvasElementId: UUID?
+    @Published var currentlySelectedTool: ToolbarView.SelectedAnnotationTool?
 
     // Reposition drag gesture
     private var dragStartLocation: CGPoint?
@@ -21,6 +22,7 @@ class CanvasViewModel: ObservableObject {
 
     init(canvasSize: CGFloat) {
         self.canvasSize = canvasSize
+        self.currentlySelectedTool = ToolbarView.SelectedAnnotationTool.pen
     }
 
     convenience init() {
@@ -186,6 +188,10 @@ extension CanvasViewModel {
 
 // MARK: Annotation palette controls
 extension CanvasViewModel {
+    var isAnnotationPaletteActive: Bool {
+        currentlySelectedTool != nil
+    }
+
     func switchAnnotationTool(_ newTool: PKTool) {
         annotationPalette.switchTool(newTool)
     }

--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
@@ -234,17 +234,13 @@ extension CanvasViewModel {
 // MARK: Annotation palette controls button handlers
 extension CanvasViewModel {
     func selectPenAnnotationTool() {
-        if currentlySelectedTool == .pen {
-            shouldShowAnnotationMenu = true
-        }
+        shouldShowAnnotationMenu = currentlySelectedTool == .pen
         currentlySelectedTool = .pen
         switchAnnotationTool(getDefaultAnnotationTool(PKInkingTool.InkType.pen))
     }
 
     func selectMarkerAnnotationTool() {
-        if currentlySelectedTool == .marker {
-            shouldShowAnnotationMenu = true
-        }
+        shouldShowAnnotationMenu = currentlySelectedTool == .marker
         currentlySelectedTool = .marker
         switchAnnotationTool(getDefaultAnnotationTool(PKInkingTool.InkType.marker))
     }

--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
@@ -10,7 +10,14 @@ class CanvasViewModel: ObservableObject {
     @Published var canvasCenterOffsetY: CGFloat = 0.0
     @Published var scaleFactor: CGFloat = 1.0
     @Published var selectedCanvasElementId: UUID?
-    @Published var currentlySelectedTool: ToolbarView.SelectedAnnotationTool?
+    @Published var currentlySelectedTool: ToolbarView.SelectedAnnotationTool? {
+        didSet {
+            // Reset the selected canvas element if an annotation tool is selected.
+            if currentlySelectedTool != nil {
+                selectedCanvasElementId = nil
+            }
+        }
+    }
     @Published var shouldShowAnnotationMenu = false
 
     // Reposition drag gesture
@@ -233,6 +240,10 @@ extension CanvasViewModel {
 
 // MARK: Annotation palette controls button handlers
 extension CanvasViewModel {
+    func selectNoAnnotationTool() {
+        currentlySelectedTool = nil
+    }
+
     func selectPenAnnotationTool() {
         shouldShowAnnotationMenu = currentlySelectedTool == .pen
         currentlySelectedTool = .pen

--- a/Dynavity/Dynavity/view/ToolbarView.swift
+++ b/Dynavity/Dynavity/view/ToolbarView.swift
@@ -32,7 +32,7 @@ struct ToolbarView: View {
     @State private var activeSheet: ActiveSheet?
     @Binding var shouldShowSideMenu: Bool
     @State private var shouldShowAnnotationMenu = false
-    @State private var currentlySelectedTool = SelectedAnnotationTool.pen
+    @State private var currentlySelectedTool: SelectedAnnotationTool? = SelectedAnnotationTool.pen
 
     let columns = [
         GridItem(.flexible()),
@@ -139,6 +139,19 @@ struct ToolbarView: View {
         .frame(width: 200, height: 100, alignment: .center)
     }
 
+    private var canvasElementSelectionButton: some View {
+        Button(action: {
+            currentlySelectedTool = nil
+        }) {
+            Image(systemName: "hand.tap")
+                .resizable()
+                .frame(width: toolButtonSize, height: toolButtonSize, alignment: .center)
+        }
+        .background(currentlySelectedTool == nil
+                        ? Color.UI.grey
+                        : nil)
+    }
+
     private var penSelectionButton: some View {
         Button(action: {
             if currentlySelectedTool == .pen {
@@ -207,6 +220,7 @@ struct ToolbarView: View {
     var body: some View {
         HStack {
             Spacer()
+            canvasElementSelectionButton
             penSelectionButton
             markerSelectionButton
             eraserSelectionButton

--- a/Dynavity/Dynavity/view/ToolbarView.swift
+++ b/Dynavity/Dynavity/view/ToolbarView.swift
@@ -137,7 +137,7 @@ struct ToolbarView: View {
 
     private var canvasElementSelectionButton: some View {
         Button(action: {
-            viewModel.currentlySelectedTool = nil
+            viewModel.selectNoAnnotationTool()
         }) {
             Image(systemName: "hand.tap")
                 .resizable()

--- a/Dynavity/Dynavity/view/ToolbarView.swift
+++ b/Dynavity/Dynavity/view/ToolbarView.swift
@@ -12,17 +12,6 @@ struct ToolbarView: View {
         }
     }
 
-    enum SelectedAnnotationTool: Identifiable {
-        case pen
-        case marker
-        case eraser
-        case lasso
-
-        var id: Int {
-            hashValue
-        }
-    }
-
     private let height: CGFloat = 25.0
     private let padding: CGFloat = 10.0
     private let toolButtonSize: CGFloat = 25.0
@@ -143,7 +132,7 @@ struct ToolbarView: View {
                 .resizable()
                 .frame(width: toolButtonSize, height: toolButtonSize, alignment: .center)
         }
-        .background(viewModel.currentlySelectedTool == nil
+        .background(viewModel.canvasMode == .selection
                         ? Color.UI.grey
                         : nil)
     }
@@ -156,11 +145,11 @@ struct ToolbarView: View {
                 .resizable()
                 .frame(width: toolButtonSize, height: toolButtonSize, alignment: .center)
         }
-        .background(viewModel.currentlySelectedTool == SelectedAnnotationTool.pen
+        .background(viewModel.canvasMode == .pen
                         ? Color.UI.grey
                         : nil)
         .overlay(viewModel.shouldShowAnnotationMenu &&
-                    viewModel.currentlySelectedTool == SelectedAnnotationTool.pen
+                    viewModel.canvasMode == .pen
                     ? annotationMenu
                     : nil)
     }
@@ -173,9 +162,9 @@ struct ToolbarView: View {
                 .resizable()
                 .frame(width: toolButtonSize, height: toolButtonSize, alignment: .center)
         }
-        .background(viewModel.currentlySelectedTool == SelectedAnnotationTool.marker ? Color.UI.grey : nil)
+        .background(viewModel.canvasMode == .marker ? Color.UI.grey : nil)
         .overlay(viewModel.shouldShowAnnotationMenu &&
-                    viewModel.currentlySelectedTool == SelectedAnnotationTool.marker
+                    viewModel.canvasMode == .marker
                     ? annotationMenu
                     : nil)
     }
@@ -188,7 +177,7 @@ struct ToolbarView: View {
                 .resizable()
                 .frame(width: toolButtonSize / 1.5, height: toolButtonSize, alignment: .center)
         }
-        .background(viewModel.currentlySelectedTool == SelectedAnnotationTool.eraser ? Color.UI.grey : nil)
+        .background(viewModel.canvasMode == .eraser ? Color.UI.grey : nil)
     }
 
     private var lassoSelectionButton: some View {
@@ -199,7 +188,7 @@ struct ToolbarView: View {
                 .resizable()
                 .frame(width: toolButtonSize, height: toolButtonSize, alignment: .center)
         }
-        .background(viewModel.currentlySelectedTool == SelectedAnnotationTool.lasso ? Color.UI.grey : nil)
+        .background(viewModel.canvasMode == .lasso ? Color.UI.grey : nil)
     }
 
     var body: some View {

--- a/Dynavity/Dynavity/view/ToolbarView.swift
+++ b/Dynavity/Dynavity/view/ToolbarView.swift
@@ -126,7 +126,7 @@ struct ToolbarView: View {
 
     private var canvasElementSelectionButton: some View {
         Button(action: {
-            viewModel.selectNoAnnotationTool()
+            viewModel.clearSelectedAnnotationTool()
         }) {
             Image(systemName: "hand.tap")
                 .resizable()

--- a/Dynavity/Dynavity/view/ToolbarView.swift
+++ b/Dynavity/Dynavity/view/ToolbarView.swift
@@ -31,7 +31,6 @@ struct ToolbarView: View {
     @ObservedObject var viewModel: CanvasViewModel
     @State private var activeSheet: ActiveSheet?
     @Binding var shouldShowSideMenu: Bool
-    @State private var shouldShowAnnotationMenu = false
 
     let columns = [
         GridItem(.flexible()),
@@ -109,8 +108,7 @@ struct ToolbarView: View {
             LazyVGrid(columns: columns, spacing: 20) {
                 ForEach(viewModel.getAnnotationWidths(), id: \.self) { width in
                     Button(action: {
-                        viewModel.switchAnnotationWidth(width)
-                        shouldShowAnnotationMenu = false
+                        viewModel.selectAnnotationWidth(width)
                     }) {
                         ZStack {
                             Circle()
@@ -126,8 +124,7 @@ struct ToolbarView: View {
             LazyVGrid(columns: columns, spacing: 20) {
                 ForEach(viewModel.getAnnotationColors(), id: \.self) { color in
                     Button(action: {
-                        viewModel.switchAnnotationColor(color)
-                        shouldShowAnnotationMenu = false
+                        viewModel.selectAnnotationColor(color)
                     }) {
                         Circle().fill(Color(color))
                     }.frame(width: selectorSize, height: selectorSize)
@@ -153,12 +150,7 @@ struct ToolbarView: View {
 
     private var penSelectionButton: some View {
         Button(action: {
-            if viewModel.currentlySelectedTool == .pen {
-                shouldShowAnnotationMenu = true
-            }
-            viewModel.currentlySelectedTool = .pen
-            viewModel.switchAnnotationTool(viewModel.getDefaultAnnotationTool(PKInkingTool.InkType.pen))
-
+            viewModel.selectPenAnnotationTool()
         }) {
             Image(systemName: "pencil")
                 .resizable()
@@ -167,7 +159,7 @@ struct ToolbarView: View {
         .background(viewModel.currentlySelectedTool == SelectedAnnotationTool.pen
                         ? Color.UI.grey
                         : nil)
-        .overlay(shouldShowAnnotationMenu &&
+        .overlay(viewModel.shouldShowAnnotationMenu &&
                     viewModel.currentlySelectedTool == SelectedAnnotationTool.pen
                     ? annotationMenu
                     : nil)
@@ -175,18 +167,14 @@ struct ToolbarView: View {
 
     private var markerSelectionButton: some View {
         Button(action: {
-            if viewModel.currentlySelectedTool == .marker {
-                shouldShowAnnotationMenu = true
-            }
-            viewModel.currentlySelectedTool = .marker
-            viewModel.switchAnnotationTool(viewModel.getDefaultAnnotationTool(PKInkingTool.InkType.marker))
+            viewModel.selectMarkerAnnotationTool()
         }) {
             Image(systemName: "highlighter")
                 .resizable()
                 .frame(width: toolButtonSize, height: toolButtonSize, alignment: .center)
         }
         .background(viewModel.currentlySelectedTool == SelectedAnnotationTool.marker ? Color.UI.grey : nil)
-        .overlay(shouldShowAnnotationMenu &&
+        .overlay(viewModel.shouldShowAnnotationMenu &&
                     viewModel.currentlySelectedTool == SelectedAnnotationTool.marker
                     ? annotationMenu
                     : nil)
@@ -194,8 +182,7 @@ struct ToolbarView: View {
 
     private var eraserSelectionButton: some View {
         Button(action: {
-            viewModel.currentlySelectedTool = .eraser
-            viewModel.switchAnnotationTool(PKEraserTool(.vector))
+            viewModel.selectEraserAnnotationTool()
         }) {
             Image(systemName: "rectangle.portrait")
                 .resizable()
@@ -206,8 +193,7 @@ struct ToolbarView: View {
 
     private var lassoSelectionButton: some View {
         Button(action: {
-            viewModel.currentlySelectedTool = .lasso
-            viewModel.switchAnnotationTool(PKLassoTool())
+            viewModel.selectLassoAnnotationTool()
         }) {
             Image(systemName: "lasso")
                 .resizable()

--- a/Dynavity/Dynavity/view/ToolbarView.swift
+++ b/Dynavity/Dynavity/view/ToolbarView.swift
@@ -12,7 +12,7 @@ struct ToolbarView: View {
         }
     }
 
-    private enum SelectedAnnotationTool: Identifiable {
+    enum SelectedAnnotationTool: Identifiable {
         case pen
         case marker
         case eraser
@@ -32,7 +32,6 @@ struct ToolbarView: View {
     @State private var activeSheet: ActiveSheet?
     @Binding var shouldShowSideMenu: Bool
     @State private var shouldShowAnnotationMenu = false
-    @State private var currentlySelectedTool: SelectedAnnotationTool? = SelectedAnnotationTool.pen
 
     let columns = [
         GridItem(.flexible()),
@@ -141,23 +140,23 @@ struct ToolbarView: View {
 
     private var canvasElementSelectionButton: some View {
         Button(action: {
-            currentlySelectedTool = nil
+            viewModel.currentlySelectedTool = nil
         }) {
             Image(systemName: "hand.tap")
                 .resizable()
                 .frame(width: toolButtonSize, height: toolButtonSize, alignment: .center)
         }
-        .background(currentlySelectedTool == nil
+        .background(viewModel.currentlySelectedTool == nil
                         ? Color.UI.grey
                         : nil)
     }
 
     private var penSelectionButton: some View {
         Button(action: {
-            if currentlySelectedTool == .pen {
+            if viewModel.currentlySelectedTool == .pen {
                 shouldShowAnnotationMenu = true
             }
-            currentlySelectedTool = .pen
+            viewModel.currentlySelectedTool = .pen
             viewModel.switchAnnotationTool(viewModel.getDefaultAnnotationTool(PKInkingTool.InkType.pen))
 
         }) {
@@ -165,56 +164,56 @@ struct ToolbarView: View {
                 .resizable()
                 .frame(width: toolButtonSize, height: toolButtonSize, alignment: .center)
         }
-        .background(currentlySelectedTool == SelectedAnnotationTool.pen
+        .background(viewModel.currentlySelectedTool == SelectedAnnotationTool.pen
                         ? Color.UI.grey
                         : nil)
         .overlay(shouldShowAnnotationMenu &&
-                    currentlySelectedTool == SelectedAnnotationTool.pen
+                    viewModel.currentlySelectedTool == SelectedAnnotationTool.pen
                     ? annotationMenu
                     : nil)
     }
 
     private var markerSelectionButton: some View {
         Button(action: {
-            if currentlySelectedTool == .marker {
+            if viewModel.currentlySelectedTool == .marker {
                 shouldShowAnnotationMenu = true
             }
-            currentlySelectedTool = .marker
+            viewModel.currentlySelectedTool = .marker
             viewModel.switchAnnotationTool(viewModel.getDefaultAnnotationTool(PKInkingTool.InkType.marker))
         }) {
             Image(systemName: "highlighter")
                 .resizable()
                 .frame(width: toolButtonSize, height: toolButtonSize, alignment: .center)
         }
-        .background(currentlySelectedTool == SelectedAnnotationTool.marker ? Color.UI.grey : nil)
+        .background(viewModel.currentlySelectedTool == SelectedAnnotationTool.marker ? Color.UI.grey : nil)
         .overlay(shouldShowAnnotationMenu &&
-                    currentlySelectedTool == SelectedAnnotationTool.marker
+                    viewModel.currentlySelectedTool == SelectedAnnotationTool.marker
                     ? annotationMenu
                     : nil)
     }
 
     private var eraserSelectionButton: some View {
         Button(action: {
-            currentlySelectedTool = .eraser
+            viewModel.currentlySelectedTool = .eraser
             viewModel.switchAnnotationTool(PKEraserTool(.vector))
         }) {
             Image(systemName: "rectangle.portrait")
                 .resizable()
                 .frame(width: toolButtonSize / 1.5, height: toolButtonSize, alignment: .center)
         }
-        .background(currentlySelectedTool == SelectedAnnotationTool.eraser ? Color.UI.grey : nil)
+        .background(viewModel.currentlySelectedTool == SelectedAnnotationTool.eraser ? Color.UI.grey : nil)
     }
 
     private var lassoSelectionButton: some View {
         Button(action: {
-            currentlySelectedTool = .lasso
+            viewModel.currentlySelectedTool = .lasso
             viewModel.switchAnnotationTool(PKLassoTool())
         }) {
             Image(systemName: "lasso")
                 .resizable()
                 .frame(width: toolButtonSize, height: toolButtonSize, alignment: .center)
         }
-        .background(currentlySelectedTool == SelectedAnnotationTool.lasso ? Color.UI.grey : nil)
+        .background(viewModel.currentlySelectedTool == SelectedAnnotationTool.lasso ? Color.UI.grey : nil)
     }
 
     var body: some View {

--- a/Dynavity/Dynavity/view/canvas/CanvasView.swift
+++ b/Dynavity/Dynavity/view/canvas/CanvasView.swift
@@ -16,13 +16,14 @@ struct CanvasView: View {
     var body: some View {
         GeometryReader { geometry in
             ZStack {
-                AnnotationCanvasView(viewModel: viewModel)
                 CanvasElementMapView(viewModel: viewModel)
                     .scaleEffect(viewModel.scaleFactor)
                     .offset(
                         x: calculateOffsetX(width: geometry.size.width),
                         y: calculateOffsetY(height: geometry.size.height)
                     )
+                AnnotationCanvasView(viewModel: viewModel)
+                    .disabled(!viewModel.isAnnotationPaletteActive)
             }
         }
     }

--- a/Dynavity/Dynavity/view/canvas/CanvasView.swift
+++ b/Dynavity/Dynavity/view/canvas/CanvasView.swift
@@ -23,7 +23,7 @@ struct CanvasView: View {
                         y: calculateOffsetY(height: geometry.size.height)
                     )
                 AnnotationCanvasView(viewModel: viewModel)
-                    .disabled(!viewModel.isAnnotationPaletteActive)
+                    .disabled(viewModel.canvasMode == .selection)
             }
         }
     }


### PR DESCRIPTION
Also made the following changes:
* Moved button handlers out of `CanvasView`, into `CanvasViewModel` to better conform to the MVVM architecture.
* Fixed the annotation menu not closing upon switching tools.
  * Previously, if you opened the annotation menu on either the pen/marker tool, then switch to the other tool, the annotation menu would appear for the other tool as well.