### PR TITLE
Fix scroll to top issue

### DIFF
--- a/Dynavity/Dynavity/view/canvas/AnnotationCanvasView.swift
+++ b/Dynavity/Dynavity/view/canvas/AnnotationCanvasView.swift
@@ -54,6 +54,7 @@ extension AnnotationCanvasView: UIViewRepresentable {
         annotationCanvasView.maximumZoomScale = CGFloat(2.0)
         annotationCanvasView.bouncesZoom = false
         annotationCanvasView.contentOffset = viewModel.canvasOrigin
+        annotationCanvasView.scrollsToTop = false
 
         return annotationCanvasView
     }


### PR DESCRIPTION
Fix issue where interacting with the toolbar causing the canvas elements to "disappear". This happens when the `AnnotationCanvas` scrolls to the top when we tap on the status bar.