### PR TITLE
Refactor CodeElementViewModel

### DIFF
--- a/Dynavity/Dynavity/networking/CodeExecutor.swift
+++ b/Dynavity/Dynavity/networking/CodeExecutor.swift
@@ -1,0 +1,5 @@
+import Combine
+
+protocol CodeExecutor {
+    func getOutputPublisher(program: String, language: CodeElement.CodeLanguage) -> AnyPublisher<String, Never>
+}

--- a/Dynavity/Dynavity/networking/RunnableCodeExecutor.swift
+++ b/Dynavity/Dynavity/networking/RunnableCodeExecutor.swift
@@ -1,0 +1,113 @@
+import Combine
+import Foundation
+
+struct RunnableCodeExecutor: CodeExecutor {
+
+    private static let endpoint = "wss://t8jfxu45v2.execute-api.us-east-2.amazonaws.com/production/"
+
+    func getOutputPublisher(program: String, language: CodeElement.CodeLanguage) -> AnyPublisher<String, Never> {
+        let connection = createNewConnection()
+        let outputStream = PassthroughSubject<String, Never>()
+
+        // initial launch command
+        let launchBody = [
+            "action": "launch",
+            "mode": "compile",
+            "lang": language.backendName,
+            "prog": program
+        ]
+        guard let launchCommand = try? JSONSerialization
+                .data(withJSONObject: launchBody, options: .prettyPrinted) else {
+            fatalError("Problem serializing WebSocket data")
+        }
+        let cmd = String(data: launchCommand, encoding: .utf8)!
+        connection.send(.string(cmd)) { _ in }
+
+        // managing output
+        var containerId = ""
+        func handleMessage(containerId id: String?, output: String?) {
+            guard let id = id else {
+                // if there is no id, ignore
+                return
+            }
+            if let output = output {
+                // output exists
+                guard id == containerId else {
+                    // container does not match, ignore
+                    return
+                }
+                // container matches, publish output
+                outputStream.send(output)
+            } else {
+                // output does not exist
+                // this is a response to the launch command
+                containerId = id
+            }
+        }
+        func listenForOutput() {
+            connection.receive { response in
+                guard let json = identifyJsonMessage(from: response) else {
+                    // not in JSON format, ignore
+                    return
+                }
+                handleMessage(containerId: json["containerId"], output: json["output"])
+                // on successful JSON message, listen again
+                listenForOutput()
+            }
+        }
+        // initial call to start the recursion
+        listenForOutput()
+
+        return outputStream
+            // on cancel, clean up the connection
+            .handleEvents(receiveCancel: connection.cancel)
+            // return an AnyPublisher
+            .eraseToAnyPublisher()
+    }
+
+    private func createNewConnection() -> URLSessionWebSocketTask {
+        guard let url = URL(string: RunnableCodeExecutor.endpoint) else {
+            fatalError("Invalid URL")
+        }
+        let connection = URLSession.shared.webSocketTask(with: url)
+        connection.resume()
+        return connection
+    }
+
+    private func identifyJsonMessage(from response: Result<URLSessionWebSocketTask.Message, Error>)
+    -> [String: String]? {
+        // attempt to read it as a text string, as opposed to reading as binary data
+        // this is due to limitations on the backend (does not work with binary data)
+        guard let text = identifyTextMessage(from: response) else {
+            return nil
+        }
+        // attempt to parse it into a [String:String] mapping
+        return toJsonDict(text: text)
+    }
+
+    private func toJsonDict(text: String) -> [String: String]? {
+        guard let data = text.data(using: .utf8),
+              let jsonAny = try? JSONSerialization.jsonObject(with: data, options: []),
+              let jsonDict = jsonAny as? [String: String] else {
+            return nil
+        }
+        return jsonDict
+    }
+
+    private func identifyTextMessage(from response: Result<URLSessionWebSocketTask.Message, Error>) -> String? {
+        switch response {
+        case .failure:
+            return nil
+        case .success(let message):
+            switch message {
+            case .string(let text):
+                return text
+            case .data:
+                return nil
+            @unknown default:
+                return nil
+            }
+        }
+    }
+
+}

--- a/Dynavity/Dynavity/view-model/canvas/elements/CodeElementViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/elements/CodeElementViewModel.swift
@@ -1,21 +1,15 @@
 import SwiftUI
+import Combine
 
 class CodeElementViewModel: ObservableObject {
     @Published var codeSnippet: CodeElement
     @Published var output: String = ""
 
-    private var connection: URLSessionWebSocketTask
-    private var containerId: String = ""
+    // allows cancellation of the current execution (e.g. to make way for a new execution)
+    private var currentExecution: AnyCancellable?
 
     init(codeSnippet: CodeElement) {
         self.codeSnippet = codeSnippet
-
-        let endpointUrl = "wss://t8jfxu45v2.execute-api.us-east-2.amazonaws.com/production/"
-        guard let url = URL(string: endpointUrl) else {
-            fatalError("Endpoint URL is an invalid constant")
-        }
-        let connection = URLSession(configuration: .default).webSocketTask(with: url)
-        self.connection = connection
     }
 
     func runCode() {
@@ -24,66 +18,17 @@ class CodeElementViewModel: ObservableObject {
             // backend will not accept an empty program
             return
         }
-        connection.resume()
         clearOutput()
-        let launchBody = [
-            "action": "launch",
-            "mode": "compile",
-            "lang": codeSnippet.language.backendName,
-            "prog": program
-        ]
-
-        guard let launchCommand = try? JSONSerialization
-                .data(withJSONObject: launchBody, options: .prettyPrinted) else {
-            // problem serializing data
-            return
+        if let previousExecution = currentExecution {
+            previousExecution.cancel()
         }
-        let cmd = String(data: launchCommand, encoding: .utf8)!
-        connection.send(.string(cmd)) { _ in }
-        listenForOutput()
-    }
-
-    func listenForOutput() {
-        func processTextResponse(text: String) {
-            guard let data = text.data(using: .utf8),
-                  let jsonAny = try? JSONSerialization.jsonObject(with: data, options: []),
-                  let jsonDict = jsonAny as? [String: String],
-                  let container = jsonDict["containerId"] else {
-                return
-            }
-            if let output = jsonDict["output"] {
-                guard container == self.containerId else {
-                    // ignore output from a different container
-                    return
-                }
-                DispatchQueue.main.async {
-                    self.addOutput(line: output)
-                }
-            } else {
-                // response from container
-                self.containerId = container
+        let executor: CodeExecutor = RunnableCodeExecutor()
+        let outputStream = executor.getOutputPublisher(program: program, language: codeSnippet.language)
+        currentExecution = outputStream.sink { output in
+            DispatchQueue.main.async {
+                self.addOutput(line: output)
             }
         }
-
-        func identifyMessage(response: Result<URLSessionWebSocketTask.Message, Error>) {
-            switch response {
-            case .failure(let error):
-                print(error)
-            case .success(let message):
-                switch message {
-                case .string(let text):
-                    print(text)
-                    processTextResponse(text: text)
-                case .data(let data):
-                    print(data)
-                @unknown default:
-                    fatalError("Unknown message type")
-                }
-                // continue listening for output only on success
-                self.listenForOutput()
-            }
-        }
-        connection.receive(completionHandler: identifyMessage)
     }
 
     func addOutput(line: String) {


### PR DESCRIPTION
Similar to #26, but for code elements. This makes `CodeElementViewModel` less coupled with the low-level WebSocket implementation of the code execution, allowing the implementation to be easily substituted in future (e.g. by executing locally instead).

## Notes

- We want execution output to be generated line by line, as opposed to all at once when the execution has terminated. This makes the user program appear more responsive, and will still show some output even if the program does not eventually terminate (e.g. stuck in infinite loop or blocking on user input).
  - Thus, we want an asynchronous publisher that is able to stream the output line by line.
  - The concrete implementation `RunnableCodeExecutor` uses [`PassthroughSubject`](https://developer.apple.com/documentation/combine/passthroughsubject) as the publisher, but it is not known to the rest of the client as it has been erased into an `AnyPublisher`.
- The client (`CodeElementViewModel`) subscribes to the publisher using `sink`, which processes each incoming element (line of output) once available.