### PR TITLE
Enable scrolling on code execution output

### DIFF
--- a/Dynavity/Dynavity/view/canvas/elements/CodeElementView.swift
+++ b/Dynavity/Dynavity/view/canvas/elements/CodeElementView.swift
@@ -9,37 +9,45 @@ struct CodeElementView: View {
 
     var body: some View {
         HStack {
-            VStack {
-                TextEditor(text: $viewModel.codeSnippet.text)
-                    .font(.custom("Courier", size: viewModel.codeSnippet.fontSize))
-                    .autocapitalization(.none)
-                    .disableAutocorrection(true)
-                    .onChange(of: viewModel.codeSnippet.text) {_ in
-                        viewModel.convertQuotes()
-                    }
-                Divider()
-                HStack {
-                    Picker("Language", selection: $viewModel.codeSnippet.language) {
-                        ForEach(CodeElement.CodeLanguage.allCases) {
-                            Text($0.displayName).tag($0)
-                        }
-                    }
-                    .pickerStyle(SegmentedPickerStyle())
-                    .onChange(of: viewModel.codeSnippet.language) {_ in
-                        viewModel.resetCodeTemplate()
-                    }
-                    Button(action: viewModel.runCode, label: {
-                        Text("Run")
-                    })
-                    .frame(maxWidth: .infinity)
-                }
-            }
+            codeWindow
             Divider()
-            ScrollView {
-                Text(viewModel.output)
-            }
+            outputWindow
         }
         .padding()
+    }
+
+    private var codeWindow: some View {
+        VStack {
+            TextEditor(text: $viewModel.codeSnippet.text)
+                .font(.custom("Courier", size: viewModel.codeSnippet.fontSize))
+                .autocapitalization(.none)
+                .disableAutocorrection(true)
+                .onChange(of: viewModel.codeSnippet.text) {_ in
+                    viewModel.convertQuotes()
+                }
+            Divider()
+            HStack {
+                Picker("Language", selection: $viewModel.codeSnippet.language) {
+                    ForEach(CodeElement.CodeLanguage.allCases) {
+                        Text($0.displayName).tag($0)
+                    }
+                }
+                .pickerStyle(SegmentedPickerStyle())
+                .onChange(of: viewModel.codeSnippet.language) {_ in
+                    viewModel.resetCodeTemplate()
+                }
+                Button(action: viewModel.runCode, label: {
+                    Text("Run")
+                })
+                .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    private var outputWindow: some View {
+        ScrollView {
+            Text(viewModel.output)
+        }
     }
 }
 

--- a/Dynavity/Dynavity/view/canvas/elements/CodeElementView.swift
+++ b/Dynavity/Dynavity/view/canvas/elements/CodeElementView.swift
@@ -35,7 +35,9 @@ struct CodeElementView: View {
                 }
             }
             Divider()
-            Text(viewModel.output)
+            ScrollView {
+                Text(viewModel.output)
+            }
         }
         .padding()
     }


### PR DESCRIPTION
If the output of a code execution spans many lines, the bottom is truncated to ... as the output area is not scrollable. This can be fixed by wrapping the output in a `ScrollView`.

## Notes
- The basic change is very simple: https://github.com/Dynavity/dynavity/commit/db98e840242571e467e386b54d7b3b22513505aa
- However, this causes SwiftLint to complain about the length of the closure body, so I had to split the `body` into some smaller components.
  - Despite `outputWindow` being much smaller/simpler compared to `codeWindow`, both have been extracted to their respective components in order to keep a similar level of abstraction within the `body`.