### PR TITLE
Add navigation to canvas from graph

### DIFF
--- a/Dynavity/Dynavity/view-model/graph/GraphMapViewModel.swift
+++ b/Dynavity/Dynavity/view-model/graph/GraphMapViewModel.swift
@@ -5,8 +5,10 @@ import Foundation
 class GraphMapViewModel: ObservableObject {
     @Published var backlinkEngine = BacklinkEngine()
 
-    private var selectedNodeOriginalPosition: CGPoint?
-    @Published var selectedNode: BacklinkNode?
+    private var draggedNodeOriginalPosition: CGPoint?
+    @Published var draggedNode: BacklinkNode?
+
+    @Published var longPressedNode: BacklinkNode?
 
     init() {
         initialiseBacklinkEngine()
@@ -45,8 +47,8 @@ extension GraphMapViewModel {
             let dist = tapPos.distance(to: processedPosition) / viewportZoomScale
 
             if dist < NodeView.radius {
-                selectedNode = node
-                selectedNodeOriginalPosition = node.position
+                draggedNode = node
+                draggedNodeOriginalPosition = node.position
             }
         }
     }
@@ -57,19 +59,19 @@ extension GraphMapViewModel {
 
     func handleNodeDragEnd(_ value: DragGesture.Value, viewportZoomScale: CGFloat) {
         processNodeTranslation(translation: value.translation, viewportZoomScale: viewportZoomScale)
-        selectedNodeOriginalPosition = nil
-        selectedNode = nil
+        draggedNodeOriginalPosition = nil
+        draggedNode = nil
     }
 
     private func processNodeTranslation(translation: CGSize, viewportZoomScale: CGFloat) {
-        guard let selectedNode = selectedNode,
-              let selectedNodeOriginalPosition = selectedNodeOriginalPosition else {
+        guard let draggedNode = draggedNode,
+              let draggedNodeOriginalPosition = draggedNodeOriginalPosition else {
             return
         }
 
         let scaledDownTranslation = translation / viewportZoomScale
-        let updatedPos = selectedNodeOriginalPosition + scaledDownTranslation
-        backlinkEngine.moveBacklinkNode(selectedNode, to: updatedPos)
+        let updatedPos = draggedNodeOriginalPosition + scaledDownTranslation
+        backlinkEngine.moveBacklinkNode(draggedNode, to: updatedPos)
     }
 
     private func getPositionRelativeToViewport(point: CGPoint,

--- a/Dynavity/Dynavity/view/graph/GraphView.swift
+++ b/Dynavity/Dynavity/view/graph/GraphView.swift
@@ -15,6 +15,8 @@ struct GraphView: View {
 
     @Binding var searchQuery: String
 
+    @State var shouldGoToCanvasView = false
+
     var body: some View {
         GeometryReader { geometry in
             ZStack {
@@ -42,8 +44,7 @@ struct GraphView: View {
     var nodesView: some View {
         ZStack {
             ForEach(viewModel.getNodes(), id: \.id) { node in
-                NodeView(label: node.name, isHighlighted: doesInputMatchSearchQuery(input: node.name))
-                    .offset(x: node.position.x, y: node.position.y)
+                getNavigationNodeView(for: node)
             }
         }
     }
@@ -54,6 +55,27 @@ struct GraphView: View {
                 EdgeView(start: edge.source.position, end: edge.destination.position)
                     .stroke()
             }
+        }
+    }
+
+    /// Returns a `View` that groups a `NodeView` alongside a `NavigationLink`.
+    /// On long pressing the `NodeView`, the view will be navigated to the `MainView`
+    /// Referenced from https://stackoverflow.com/a/62055596
+    private func getNavigationNodeView(for node: BacklinkNode) -> some View {
+        Group {
+            // TODO: pass in the relevant canvas to mainView once storage has been implemented
+            NavigationLink(destination: MainView()
+                            .navigationBarHidden(true)
+                            .navigationBarBackButtonHidden(true),
+                           isActive: $shouldGoToCanvasView) {
+                EmptyView()
+            }
+
+            NodeView(label: node.name, isHighlighted: doesInputMatchSearchQuery(input: node.name))
+                .offset(x: node.position.x, y: node.position.y)
+                .onLongPressGesture {
+                    shouldGoToCanvasView = true
+                }
         }
     }
 }


### PR DESCRIPTION
Changes:
- Add ability to navigate to canvas from graph view by long press on the relevant nodes 
- Renamed `selectedNode` to `draggedNode` to prevent confusion
