### PR TITLE
Delete canvas elements

### DIFF
--- a/Dynavity/Dynavity/model/canvas/Canvas.swift
+++ b/Dynavity/Dynavity/model/canvas/Canvas.swift
@@ -18,6 +18,14 @@ struct Canvas {
         canvasElements.append(element)
     }
 
+    mutating func removeElement(_ element: CanvasElementProtocol) {
+        guard let index = canvasElements.firstIndex(where: { $0.id == element.id }) else {
+            return
+        }
+
+        canvasElements.remove(at: index)
+    }
+
     mutating func replaceElement(_ element: CanvasElementProtocol) {
         guard let index = canvasElements.firstIndex(where: { $0.id == element.id }) else {
             return

--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
@@ -58,7 +58,7 @@ class CanvasViewModel: ObservableObject {
     }
 }
 
-// MARK: Adding of canvas elements
+// MARK: Adding/removing of canvas elements
 extension CanvasViewModel {
     func addImageElement(from image: UIImage) {
         let imageCanvasElement = ImageElement(position: canvasOrigin, image: image)
@@ -98,6 +98,10 @@ extension CanvasViewModel {
         case .rectangle:
             canvas.addElement(RectangleUmlElement(position: canvasOrigin))
         }
+    }
+
+    func removeElement(_ element: CanvasElementProtocol) {
+        canvas.removeElement(element)
     }
 }
 

--- a/Dynavity/Dynavity/view/SelectionOverlayView.swift
+++ b/Dynavity/Dynavity/view/SelectionOverlayView.swift
@@ -91,8 +91,6 @@ struct SelectionOverlayView: View {
         }
         .gesture(rotationGesture)
         .offset(y: extendedControlOffset)
-        // Force the rotation control to be the same size regardless of scale factor.
-        .scaleEffect(1.0 / viewModel.scaleFactor)
     }
 
     private var dragGesture: some Gesture {
@@ -117,8 +115,6 @@ struct SelectionOverlayView: View {
         }
         .gesture(dragGesture)
         .offset(y: -extendedControlOffset)
-        // Force the drag control to be the same size regardless of scale factor.
-        .scaleEffect(1.0 / viewModel.scaleFactor)
     }
 
     private var deleteControl: some View {
@@ -134,8 +130,6 @@ struct SelectionOverlayView: View {
                 .frame(width: extendedControlHandleLength, height: 1.0)
         }
         .offset(x: extendedControlOffset)
-        // Force the delete control to be the same size regardless of scale factor.
-        .scaleEffect(1.0 / viewModel.scaleFactor)
     }
 
     private func makeResizeControl(_ resizeControl: ResizeControlAnchor) -> some View {
@@ -160,9 +154,13 @@ struct SelectionOverlayView: View {
     var body: some View {
         ZStack {
             outline
-            rotationControl
-            dragControl
-            deleteControl
+            ZStack {
+                rotationControl
+                dragControl
+                deleteControl
+            }
+            // Force the extended controls to be the same size regardless of scale factor.
+            .scaleEffect(1.0 / viewModel.scaleFactor)
             ForEach(ResizeControlAnchor.allCases, id: \.self) { corner in
                 makeResizeControl(corner)
             }

--- a/Dynavity/Dynavity/view/SelectionOverlayView.swift
+++ b/Dynavity/Dynavity/view/SelectionOverlayView.swift
@@ -120,6 +120,13 @@ struct SelectionOverlayView: View {
         .offset(y: -extendedControlOffsetY)
     }
 
+    private var deleteGesture: some Gesture {
+        TapGesture()
+            .onEnded {
+                viewModel.removeElement(element)
+            }
+    }
+
     private var deleteControl: some View {
         HStack(spacing: .zero) {
             Image(systemName: "trash.circle")
@@ -132,6 +139,7 @@ struct SelectionOverlayView: View {
                 .fill(overlayDestructiveColor)
                 .frame(width: extendedControlHandleLength, height: 1.0)
         }
+        .gesture(deleteGesture)
         .offset(x: extendedControlOffsetX)
     }
 

--- a/Dynavity/Dynavity/view/SelectionOverlayView.swift
+++ b/Dynavity/Dynavity/view/SelectionOverlayView.swift
@@ -13,7 +13,10 @@ struct SelectionOverlayView: View {
     private let overlayColor = Color.blue
     private let overlayDestructiveColor = Color.red
 
-    private var extendedControlOffset: CGFloat {
+    private var extendedControlOffsetX: CGFloat {
+        -(element.width * viewModel.scaleFactor + extendedControlSize + extendedControlHandleLength) / 2.0
+    }
+    private var extendedControlOffsetY: CGFloat {
         -(element.height * viewModel.scaleFactor + extendedControlSize + extendedControlHandleLength) / 2.0
     }
     private var halfWidth: CGFloat {
@@ -70,7 +73,7 @@ struct SelectionOverlayView: View {
             .onChanged { value in
                 // Calculate the translation with respect to the center of the canvas element.
                 var translationsFromCenter = value.translation
-                translationsFromCenter.height += extendedControlOffset
+                translationsFromCenter.height += extendedControlOffsetY
                 viewModel.rotateSelectedCanvasElement(by: translationsFromCenter)
             }
     }
@@ -90,7 +93,7 @@ struct SelectionOverlayView: View {
                 .frame(width: 1.0, height: extendedControlHandleLength)
         }
         .gesture(rotationGesture)
-        .offset(y: extendedControlOffset)
+        .offset(y: extendedControlOffsetY)
     }
 
     private var dragGesture: some Gesture {
@@ -114,7 +117,7 @@ struct SelectionOverlayView: View {
                 .frame(width: extendedControlSize, height: extendedControlSize)
         }
         .gesture(dragGesture)
-        .offset(y: -extendedControlOffset)
+        .offset(y: -extendedControlOffsetY)
     }
 
     private var deleteControl: some View {
@@ -129,7 +132,7 @@ struct SelectionOverlayView: View {
                 .fill(overlayDestructiveColor)
                 .frame(width: extendedControlHandleLength, height: 1.0)
         }
-        .offset(x: extendedControlOffset)
+        .offset(x: extendedControlOffsetX)
     }
 
     private func makeResizeControl(_ resizeControl: ResizeControlAnchor) -> some View {

--- a/Dynavity/Dynavity/view/SelectionOverlayView.swift
+++ b/Dynavity/Dynavity/view/SelectionOverlayView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct SelectionOverlayView: View {
     var element: CanvasElementProtocol
     @ObservedObject var viewModel: CanvasViewModel
+    @State private var shouldDisplayDeleteAlert = false
 
     private let extendedControlSize: CGFloat = 25.0
     private let extendedControlHandleLength: CGFloat = 15.0
@@ -120,10 +121,21 @@ struct SelectionOverlayView: View {
         .offset(y: -extendedControlOffsetY)
     }
 
+    private var deleteAlert: Alert {
+        Alert(
+            title: Text("Are you sure?"),
+            message: Text("This will delete the element!"),
+            primaryButton: .destructive(Text("Delete"), action: {
+                viewModel.removeElement(element)
+            }),
+            secondaryButton: .cancel()
+        )
+    }
+
     private var deleteGesture: some Gesture {
         TapGesture()
             .onEnded {
-                viewModel.removeElement(element)
+                shouldDisplayDeleteAlert = true
             }
     }
 
@@ -141,6 +153,9 @@ struct SelectionOverlayView: View {
         }
         .gesture(deleteGesture)
         .offset(x: extendedControlOffsetX)
+        .alert(isPresented: $shouldDisplayDeleteAlert) { () -> Alert in
+            deleteAlert
+        }
     }
 
     private func makeResizeControl(_ resizeControl: ResizeControlAnchor) -> some View {


### PR DESCRIPTION
I tried to use context menu, but it is extremely buggy. See this [StackOverflow](https://stackoverflow.com/questions/65118408/swiftui-contextmenu-flipping-bug) discussion for more information. You can also checkout the branch `ian/add-context-menu-delete` to see for yourself. Not only does the context menu not respect rotation, it also doesn't render the contents of more complicated elements such as PDFs and code blocks. After spending quite some time trying to make this work, I don't think it is possible (or at least not without introducing a lot of hacks).

I ended up adding the delete button to `SelectionOverlayView` as yet another extended control. Upon tapping on it, the user is prompted with an alert to confirm their action.