### PR TITLE
Add panning & zooming in canvas mode

### DIFF
--- a/Dynavity/Dynavity/view/canvas/AnnotationCanvasView.swift
+++ b/Dynavity/Dynavity/view/canvas/AnnotationCanvasView.swift
@@ -65,8 +65,13 @@ extension AnnotationCanvasView: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: PKCanvasView, context: Context) {
-        annotationCanvasView.zoomScale = viewModel.scaleFactor
-        annotationCanvasView.contentOffset = viewModel.canvasTopLeftOffset
+        if annotationCanvasView.zoomScale != viewModel.scaleFactor {
+            annotationCanvasView.zoomScale = viewModel.scaleFactor
+        }
+
+        if annotationCanvasView.contentOffset != viewModel.canvasTopLeftOffset {
+            annotationCanvasView.contentOffset = viewModel.canvasTopLeftOffset
+        }
 
         // Disable drawing by setting the tool to the eraser.
         if isDrawingDisabled {

--- a/Dynavity/Dynavity/view/canvas/AnnotationCanvasView.swift
+++ b/Dynavity/Dynavity/view/canvas/AnnotationCanvasView.swift
@@ -4,9 +4,15 @@ import PencilKit
 struct AnnotationCanvasView: View {
     @ObservedObject var viewModel: CanvasViewModel
     @State private var annotationCanvasView = PKCanvasWrapperView()
+    private let isDrawingDisabled: Bool
+
+    init(viewModel: CanvasViewModel, isDrawingDisabled: Bool) {
+        self.viewModel = viewModel
+        self.isDrawingDisabled = isDrawingDisabled
+    }
 
     init(viewModel: CanvasViewModel) {
-        self.viewModel = viewModel
+        self.init(viewModel: viewModel, isDrawingDisabled: false)
     }
 }
 
@@ -59,6 +65,12 @@ extension AnnotationCanvasView: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: PKCanvasView, context: Context) {
+        // Disable drawing by setting the tool to the eraser.
+        if isDrawingDisabled {
+            annotationCanvasView.tool = PKEraserTool(.vector)
+            return
+        }
+
         // Update annotation tool
         annotationCanvasView.tool = viewModel.getCurrentTool()
     }

--- a/Dynavity/Dynavity/view/canvas/AnnotationCanvasView.swift
+++ b/Dynavity/Dynavity/view/canvas/AnnotationCanvasView.swift
@@ -65,6 +65,9 @@ extension AnnotationCanvasView: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: PKCanvasView, context: Context) {
+        annotationCanvasView.zoomScale = viewModel.scaleFactor
+        annotationCanvasView.contentOffset = viewModel.canvasTopLeftOffset
+
         // Disable drawing by setting the tool to the eraser.
         if isDrawingDisabled {
             annotationCanvasView.tool = PKEraserTool(.vector)

--- a/Dynavity/Dynavity/view/canvas/AnnotationCanvasView.swift
+++ b/Dynavity/Dynavity/view/canvas/AnnotationCanvasView.swift
@@ -6,6 +6,11 @@ struct AnnotationCanvasView: View {
     @State private var annotationCanvasView = PKCanvasWrapperView()
     private let isDrawingDisabled: Bool
 
+    private var shouldUpdateViewport: Bool {
+        isDrawingDisabled && viewModel.canvasMode != .selection
+            || !isDrawingDisabled && viewModel.canvasMode == .selection
+    }
+
     init(viewModel: CanvasViewModel, isDrawingDisabled: Bool) {
         self.viewModel = viewModel
         self.isDrawingDisabled = isDrawingDisabled
@@ -29,11 +34,15 @@ extension AnnotationCanvasView {
     }
 
     func didZoom(to scale: CGFloat) {
-        viewModel.scaleFactor = scale
+        if !shouldUpdateViewport {
+            viewModel.scaleFactor = scale
+        }
     }
 
     func didScroll(to offset: CGPoint) {
-        viewModel.canvasTopLeftOffset = offset
+        if !shouldUpdateViewport {
+            viewModel.canvasTopLeftOffset = offset
+        }
     }
 }
 
@@ -65,11 +74,8 @@ extension AnnotationCanvasView: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: PKCanvasView, context: Context) {
-        if annotationCanvasView.zoomScale != viewModel.scaleFactor {
+        if shouldUpdateViewport {
             annotationCanvasView.zoomScale = viewModel.scaleFactor
-        }
-
-        if annotationCanvasView.contentOffset != viewModel.canvasTopLeftOffset {
             annotationCanvasView.contentOffset = viewModel.canvasTopLeftOffset
         }
 

--- a/Dynavity/Dynavity/view/canvas/CanvasView.swift
+++ b/Dynavity/Dynavity/view/canvas/CanvasView.swift
@@ -6,6 +6,7 @@ struct CanvasView: View {
     var body: some View {
         GeometryReader { geometry in
             ZStack {
+                AnnotationCanvasView(viewModel: viewModel, isDrawingDisabled: true)
                 CanvasElementMapView(viewModel: viewModel)
                     .scaleEffect(viewModel.scaleFactor)
                     .offset(viewModel.canvasViewportOffset)

--- a/Dynavity/Dynavity/view/canvas/CanvasView.swift
+++ b/Dynavity/Dynavity/view/canvas/CanvasView.swift
@@ -7,6 +7,9 @@ struct CanvasView: View {
         GeometryReader { geometry in
             ZStack {
                 AnnotationCanvasView(viewModel: viewModel, isDrawingDisabled: true)
+                    .onTapGesture {
+                        viewModel.unselectCanvasElement()
+                    }
                 CanvasElementMapView(viewModel: viewModel)
                     .scaleEffect(viewModel.scaleFactor)
                     .offset(viewModel.canvasViewportOffset)


### PR DESCRIPTION
Also added the ability to clear the canvas element selection by tapping anywhere on the canvas.

This was achieved by adding a new mode to `AnnotationCanvasView` in which its active `PKTool` is set to the eraser. I tried a few other methods, such as removing the `drawingGestureRecognizer` but those didn't seem to work. Once again, there is a memory issue that occurs only when connected to the debugger and panning & zooming the canvas very quickly.