### PR TITLE
UML connector deletion

### DIFF
--- a/Dynavity/Dynavity/model/canvas/Canvas.swift
+++ b/Dynavity/Dynavity/model/canvas/Canvas.swift
@@ -76,4 +76,12 @@ extension Canvas {
 
         umlConnectors[index] = connector
     }
+
+    mutating func removeUmlConnector(_ connector: UmlConnector) {
+        guard let index = umlConnectors.firstIndex(where: { $0.id == connector.id }) else {
+            return
+        }
+
+        umlConnectors.remove(at: index)
+    }
 }

--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel+Uml.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel+Uml.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+// MARK: UML side menu controls button handlers
+extension CanvasViewModel {
+    func showUmlMenu() {
+        shouldShowUmlMenu = true
+    }
+
+    func hideUmlMenu() {
+        shouldShowUmlMenu = false
+    }
+}
+
+// MARK: UML diagram utility functions
+extension CanvasViewModel {
+    func getCanvasUmlConnectors() -> [UmlConnector] {
+        canvas.umlConnectors
+    }
+
+    private func pointInUmlElement(_ point: CGPoint) -> UmlElementProtocol? {
+        let canvasElement = canvas.canvasElements.first { $0 is UmlElementProtocol && $0.containsPoint(point) }
+        guard let umlElement = canvasElement as? UmlElementProtocol else {
+            return nil
+        }
+        return umlElement
+    }
+
+    /// To remove dependency of `OrthogonalConnector` model with `UmlSelectionOverlayView` view
+    private func convertToConnectorAnchor(_ anchor: UmlSelectionOverlayView.ConnectorControlAnchor)
+    -> ConnectorConnectingSide {
+        switch anchor {
+        case .middleTop:
+            return .middleTop
+        case .middleBottom:
+            return .middleBottom
+        case .middleLeft:
+            return .middleLeft
+        case .middleRight:
+            return .middleRight
+        }
+    }
+
+    func handleUmlElementUpdated() {
+        guard let element = canvas.getElementBy(id: selectedCanvasElementId) else {
+            return
+        }
+        if element is UmlElementProtocol {
+            updateUmlConnections(id: selectedCanvasElementId)
+        }
+    }
+
+    func updateUmlConnections(id: UUID?) {
+        guard let id = id else {
+            return
+        }
+        var idsToRemove: [UUID] = []
+        for var connector in canvas.umlConnectors {
+            if connector.connects.fromElement != id
+                    && connector.connects.toElement != id {
+                continue
+            }
+            idsToRemove.append(connector.id)
+            let sourceId = connector.connects.fromElement
+            let destId = connector.connects.toElement
+            guard let source = canvas.getElementBy(id: sourceId) as? UmlElementProtocol,
+                  let dest = canvas.getElementBy(id: destId) as? UmlElementProtocol else {
+                return
+            }
+            let sourceAnchor = connector.connectingSide.fromSide
+            let destAnchor = connector.connectingSide.toSide
+            let newPoints = OrthogonalConnector(from: source, to: dest)
+                .generateRoute(sourceAnchor, destAnchor: destAnchor)
+            connector.points = newPoints
+            canvas.replaceUmlConnector(connector)
+        }
+    }
+}
+
+// MARK: UML connection point gestures
+extension CanvasViewModel {
+    func handleConnectionPointTap(_ element: UmlElementProtocol,
+                                  anchor: UmlSelectionOverlayView.ConnectorControlAnchor) {
+        guard let (startUmlElement, startAnchor) = umlConnectorStart else {
+            umlConnectorStart = (umlElement: element, anchor: convertToConnectorAnchor(anchor))
+            return
+        }
+        guard  umlConnectorEnd == nil else {
+            return
+        }
+        let newEndAnchor = convertToConnectorAnchor(anchor)
+        umlConnectorEnd = (umlElement: element, anchor: newEndAnchor)
+        let points = OrthogonalConnector(from: startUmlElement, to: element)
+            .generateRoute(startAnchor, destAnchor: newEndAnchor)
+        canvas.addUmlConnector(UmlConnector(points: points,
+                                            connects: (fromElement: startUmlElement.id,
+                                                       toElement: element.id),
+                                            connectingSide: (fromSide: startAnchor,
+                                                             toSide: newEndAnchor)))
+        umlConnectorStart = nil
+        umlConnectorEnd = nil
+        selectedCanvasElementId = nil
+    }
+}
+
+// MARK: UML connector gestures
+extension CanvasViewModel {
+    func select(umlConnector: UmlConnector) {
+        if selectedUmlConnectorId == umlConnector.id {
+            selectedUmlConnectorId = nil
+            return
+        }
+        selectedUmlConnectorId = umlConnector.id
+    }
+
+    func removeUmlConnector(_ connector: UmlConnector) {
+        canvas.removeUmlConnector(connector)
+    }
+}

--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
@@ -29,6 +29,7 @@ class CanvasViewModel: ObservableObject {
     @Published var shouldShowUmlMenu = false
 
     // Uml element connectors
+    @Published var selectedUmlConnectorId: UUID?
     @Published var umlConnectorStart: (umlElement: UmlElementProtocol, anchor: ConnectorConnectingSide)?
     @Published var umlConnectorEnd: (umlElement: UmlElementProtocol, anchor: ConnectorConnectingSide)?
     var canvasViewport: CGSize = .zero
@@ -247,103 +248,5 @@ extension CanvasViewModel {
     func handleDragEnd() {
         dragStartLocation = nil
         element = nil
-    }
-}
-
-// MARK: UML side menu controls button handlers
-extension CanvasViewModel {
-    func showUmlMenu() {
-        shouldShowUmlMenu = true
-    }
-
-    func hideUmlMenu() {
-        shouldShowUmlMenu = false
-    }
-}
-
-// MARK: UML diagram connector drag gesture
-extension CanvasViewModel {
-    func getCanvasUmlConnectors() -> [UmlConnector] {
-        canvas.umlConnectors
-    }
-
-    private func pointInUmlElement(_ point: CGPoint) -> UmlElementProtocol? {
-        let canvasElement = canvas.canvasElements.first { $0 is UmlElementProtocol && $0.containsPoint(point) }
-        guard let umlElement = canvasElement as? UmlElementProtocol else {
-            return nil
-        }
-        return umlElement
-    }
-
-    /// To remove dependency of `OrthogonalConnector` model with `UmlSelectionOverlayView` view
-    private func convertToConnectorAnchor(_ anchor: UmlSelectionOverlayView.ConnectorControlAnchor)
-    -> ConnectorConnectingSide {
-        switch anchor {
-        case .middleTop:
-            return .middleTop
-        case .middleBottom:
-            return .middleBottom
-        case .middleLeft:
-            return .middleLeft
-        case .middleRight:
-            return .middleRight
-        }
-    }
-
-    func handleUmlElementUpdated() {
-        guard let element = canvas.getElementBy(id: selectedCanvasElementId) else {
-            return
-        }
-        if element is UmlElementProtocol {
-            updateUmlConnections(id: selectedCanvasElementId)
-        }
-    }
-
-    func handleConnectorTap(_ element: UmlElementProtocol, anchor: UmlSelectionOverlayView.ConnectorControlAnchor) {
-        guard let (startUmlElement, startAnchor) = umlConnectorStart else {
-            umlConnectorStart = (umlElement: element, anchor: convertToConnectorAnchor(anchor))
-            return
-        }
-        guard  umlConnectorEnd == nil else {
-            return
-        }
-        let newEndAnchor = convertToConnectorAnchor(anchor)
-        umlConnectorEnd = (umlElement: element, anchor: newEndAnchor)
-        let points = OrthogonalConnector(from: startUmlElement, to: element)
-            .generateRoute(startAnchor, destAnchor: newEndAnchor)
-        canvas.addUmlConnector(UmlConnector(points: points,
-                                            connects: (fromElement: startUmlElement.id,
-                                                       toElement: element.id),
-                                            connectingSide: (fromSide: startAnchor,
-                                                             toSide: newEndAnchor)))
-        umlConnectorStart = nil
-        umlConnectorEnd = nil
-        selectedCanvasElementId = nil
-    }
-
-    func updateUmlConnections(id: UUID?) {
-        guard let id = id else {
-            return
-        }
-        var idsToRemove: [UUID] = []
-        for var connector in canvas.umlConnectors {
-            if connector.connects.fromElement != id
-                    && connector.connects.toElement != id {
-                continue
-            }
-            idsToRemove.append(connector.id)
-            let sourceId = connector.connects.fromElement
-            let destId = connector.connects.toElement
-            guard let source = canvas.getElementBy(id: sourceId) as? UmlElementProtocol,
-                  let dest = canvas.getElementBy(id: destId) as? UmlElementProtocol else {
-                return
-            }
-            let sourceAnchor = connector.connectingSide.fromSide
-            let destAnchor = connector.connectingSide.toSide
-            let newPoints = OrthogonalConnector(from: source, to: dest)
-                .generateRoute(sourceAnchor, destAnchor: destAnchor)
-            connector.points = newPoints
-            canvas.replaceUmlConnector(connector)
-        }
     }
 }

--- a/Dynavity/Dynavity/view/CanvasElementMapView.swift
+++ b/Dynavity/Dynavity/view/CanvasElementMapView.swift
@@ -10,6 +10,10 @@ struct CanvasElementMapView: View {
         viewModel.selectedCanvasElementId == element.id
     }
 
+    private func isSelected(umlConnector: UmlConnector) -> Bool {
+        viewModel.selectedUmlConnectorId == umlConnector.id
+    }
+
     private func shouldShowUmlSelectionOverlay(_ element: CanvasElementProtocol) -> Bool {
         element is UmlElementProtocol && (viewModel.umlConnectorStart != nil || isSelected(element))
     }
@@ -25,19 +29,19 @@ struct CanvasElementMapView: View {
             }
         }
         .stroke(umlConnectorLineColor, lineWidth: umlConnectorLineWidth)
-        .gesture(testGesture)
         .offset(x: viewModel.canvasOrigin.x, y: viewModel.canvasOrigin.y)
-    }
-
-    // TODO: Change this guesture to select uml connector
-    var testGesture: some Gesture {
-        TapGesture().onEnded({ _ in print("Tap gesture UML connector") })
     }
 
     var body: some View {
         ZStack {
             ForEach(viewModel.getCanvasUmlConnectors(), id: \.id) { connector in
                 generateUmlConnectors(connector)
+                    .onTapGesture {
+                        viewModel.select(umlConnector: connector)
+                    }
+                    .overlay(isSelected(umlConnector: connector)
+                                ? ConnectorSelectionOverlayView(connector: connector, viewModel: viewModel)
+                                : nil)
             }
 
             ForEach(viewModel.getCanvasElements(), id: \.id) { element in

--- a/Dynavity/Dynavity/view/CanvasElementMapView.swift
+++ b/Dynavity/Dynavity/view/CanvasElementMapView.swift
@@ -29,6 +29,9 @@ struct CanvasElementMapView: View {
             }
         }
         .stroke(umlConnectorLineColor, lineWidth: umlConnectorLineWidth)
+        .overlay(isSelected(umlConnector: connector)
+                    ? ConnectorSelectionOverlayView(connector: connector, viewModel: viewModel)
+                    : nil)
         .offset(x: viewModel.canvasOrigin.x, y: viewModel.canvasOrigin.y)
     }
 
@@ -39,9 +42,6 @@ struct CanvasElementMapView: View {
                     .onTapGesture {
                         viewModel.select(umlConnector: connector)
                     }
-                    .overlay(isSelected(umlConnector: connector)
-                                ? ConnectorSelectionOverlayView(connector: connector, viewModel: viewModel)
-                                : nil)
             }
 
             ForEach(viewModel.getCanvasElements(), id: \.id) { element in

--- a/Dynavity/Dynavity/view/ConnectorSelectionOverlayView.swift
+++ b/Dynavity/Dynavity/view/ConnectorSelectionOverlayView.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+struct ConnectorSelectionOverlayView: View {
+    var connector: UmlConnector
+    @ObservedObject var viewModel: CanvasViewModel
+    @State private var shouldDisplayDeleteAlert = true
+
+    private let overlayDestructiveColor: Color = .red
+    private let extendedControlSize: CGFloat = 25.0
+    private let extendedControlHandleLength: CGFloat = 15.0
+
+    private let connectorOverlayColor: Color = .orange
+    private let connectorOverlayWidth: CGFloat = 5.0
+
+    private var extendedControlOffsetX: CGFloat {
+        -(viewModel.scaleFactor + extendedControlSize + extendedControlHandleLength) / 2.0
+    }
+
+    private func generateConnectorOverlay(_ connector: UmlConnector) -> some View {
+        var points = connector.points
+        return Path { path in
+            let origin = points.removeFirst()
+            // Translate point to account of CanvasView offset
+            path.move(to: origin - viewModel.canvasOrigin + viewModel.canvasViewport / 2.0)
+            points.forEach {
+                path.addLine(to: $0 - viewModel.canvasOrigin + viewModel.canvasViewport / 2.0)
+            }
+        }
+        .stroke(connectorOverlayColor, lineWidth: connectorOverlayWidth)
+        .offset(x: viewModel.canvasOrigin.x, y: viewModel.canvasOrigin.y)
+    }
+
+    private var deleteAlert: Alert {
+        Alert(
+            title: Text("Are you sure?"),
+            message: Text("This will delete the element!"),
+            primaryButton: .destructive(Text("Delete"), action: {
+                viewModel.removeUmlConnector(connector)
+            }),
+            secondaryButton: .cancel()
+        )
+    }
+
+    private var deleteGesture: some Gesture {
+        TapGesture()
+            .onEnded {
+                shouldDisplayDeleteAlert = true
+            }
+    }
+
+    private var deleteControl: some View {
+        HStack(spacing: .zero) {
+            Image(systemName: "trash.circle")
+                .resizable()
+                .foregroundColor(overlayDestructiveColor)
+                .frame(width: extendedControlSize, height: extendedControlSize)
+            Rectangle()
+                .fill(overlayDestructiveColor)
+                .frame(width: extendedControlHandleLength, height: 1.0)
+        }
+        .gesture(deleteGesture)
+        .offset(x: extendedControlOffsetX)
+        .alert(isPresented: $shouldDisplayDeleteAlert) { () -> Alert in
+            deleteAlert
+        }
+    }
+
+    private var popoverMenu: some View {
+        VStack {
+            deleteControl
+        }
+        .frame(width: 200, height: 200, alignment: .center)
+        .background(Color.blue)
+    }
+
+    var body: some View {
+        VStack {
+            generateConnectorOverlay(connector)
+            popoverMenu
+        }
+    }
+}
+
+struct ConnectorSelectionOverlayView_Previews: PreviewProvider {
+    static var previews: some View {
+        let viewModel = CanvasViewModel()
+        let sourceElement = DiamondUmlElement(position: viewModel.canvasOrigin)
+        let destElement = DiamondUmlElement(position: viewModel.canvasOrigin
+                                                + CGPoint(x: 250, y: 250))
+        let umlConnector = UmlConnector(connects: (fromElement: sourceElement.id, toElement: destElement.id),
+                                        connectingSide: (fromSide: ConnectorConnectingSide.middleRight,
+                                                         toSide: ConnectorConnectingSide.middleLeft))
+        ConnectorSelectionOverlayView(connector: umlConnector, viewModel: viewModel)
+    }
+}

--- a/Dynavity/Dynavity/view/ConnectorSelectionOverlayView.swift
+++ b/Dynavity/Dynavity/view/ConnectorSelectionOverlayView.swift
@@ -27,7 +27,7 @@ struct ConnectorSelectionOverlayView: View {
         }
     }
 
-    private func getConnectorBend() -> CGPoint {
+    private func getConnectorMidPoint() -> CGPoint {
         let points = connector.points
         // Only source and dest, no bends
         if points.count == 2 {
@@ -45,7 +45,7 @@ struct ConnectorSelectionOverlayView: View {
                 .background(deleteControlBackgroundColor)
                 .frame(width: extendedControlSize, height: extendedControlSize)
         }
-        .position(getConnectorBend() - viewModel.canvasOrigin + viewModel.canvasViewport / 2.0)
+        .position(getConnectorMidPoint() - viewModel.canvasOrigin + viewModel.canvasViewport / 2.0)
         .onTapGesture {
             viewModel.removeUmlConnector(connector)
         }

--- a/Dynavity/Dynavity/view/UmlSelectionOverlayView.swift
+++ b/Dynavity/Dynavity/view/UmlSelectionOverlayView.swift
@@ -43,7 +43,7 @@ struct UmlSelectionOverlayView: View {
                 guard let element = element as? UmlElementProtocol else {
                     return
                 }
-                viewModel.handleConnectorTap(element, anchor: connectorControl)
+                viewModel.handleConnectionPointTap(element, anchor: connectorControl)
             }
 
         return Group {


### PR DESCRIPTION
## Changes made:
- Refactor `CanvasViewModel` to extract out functions related to UML diagramming feature
- Add ability to delete UML connectors after they are formed

## Notes:
To delete a UML connector:
1. Tap on the UML connector (Tap on selected UML connector again to unselect)
2. The selected connector will be highlighted, and a trash icon will appear
3. Tap on the trash icon to delete the connector.

Unlike deletion of `CanvasElementProtocol`s, the deletion of `UmlConnector`s does not require the user to confirm the deletion from a pop-up alert. I think it is not necessary for `UmlConnector` as they can easily be formed again! I also feel that accidental deletions are unlikely to occur.

![Simulator Screen Shot - iPad Pro (11-inch) (2nd generation) - 2021-04-03 at 18 35 55](https://user-images.githubusercontent.com/24553546/113476126-0d199c00-94ac-11eb-9afe-4c35bb5f9d4b.png)
