### PR TITLE
Fix choppiness with collaboration when dragging/resizing/rotating

### DIFF
--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
@@ -110,11 +110,16 @@ extension CanvasViewModel {
 
     private func loadSnapshot(_ snapshot: DataSnapshot) {
         if let data = snapshot.value,
-           let loaded = try? FirebaseDecoder().decode(Canvas.self, from: data) {
+           var loadedCanvas = try? FirebaseDecoder().decode(Canvas.self, from: data) {
             // replace the local snapshot
             DispatchQueue.main.async {
                 self.enableWriteBack = false
-                self.canvas = loaded
+                // Do not update the currently selected canvas element.
+                if let id = self.selectedCanvasElementId,
+                   let selectedCanvasElement = self.canvas.getElementBy(id: id) {
+                    loadedCanvas.replaceElement(selectedCanvasElement)
+                }
+                self.canvas = loadedCanvas
                 self.enableWriteBack = true
             }
         }


### PR DESCRIPTION
See https://github.com/Dynavity/dynavity/pull/53#issuecomment-812982458 for more context on this issue.

When updating from Firebase, we exempt the currently selected canvas element from being updated. This will potentially result in the state not being exactly the same across multiple devices but I think it isn't a problem as future updates when the canvas element is not selected will result in it being updated.