### PR TITLE
Implement element-level synchronization

### DIFF
--- a/Dynavity/Dynavity/model/CanvasElementProtocol.swift
+++ b/Dynavity/Dynavity/model/CanvasElementProtocol.swift
@@ -13,6 +13,24 @@ protocol CanvasElementProtocol: Codable {
     mutating func move(by translation: CGSize)
     mutating func resize(by translation: CGSize)
     mutating func rotate(to rotation: Double)
+
+    var observers: [ElementChangeListener] { get set }
+}
+
+protocol ElementChangeListener {
+    func notifyDidChange(newObj: CanvasElementProtocol)
+}
+
+extension CanvasElementProtocol {
+    mutating func addObserver(_ observer: ElementChangeListener) {
+        observers.append(observer)
+    }
+
+    func notifyObservers() {
+        observers.forEach {
+            $0.notifyDidChange(newObj: self)
+        }
+    }
 }
 
 // MARK: Default implementations
@@ -94,5 +112,10 @@ extension CanvasElementProtocol {
                            size: CGSize(width: width, height: height)
                             .rotate(by: CGFloat(rotation)))
         return frame.contains(point)
+    }
+
+    // Helper to implement Equatable
+    func checkId(_ other: CanvasElementProtocol) -> Bool {
+        self.id == other.id
     }
 }

--- a/Dynavity/Dynavity/model/CanvasElementProtocol.swift
+++ b/Dynavity/Dynavity/model/CanvasElementProtocol.swift
@@ -17,8 +17,8 @@ protocol CanvasElementProtocol: Codable {
     var observers: [ElementChangeListener] { get set }
 }
 
-protocol ElementChangeListener {
-    func notifyDidChange(newObj: CanvasElementProtocol)
+struct ElementChangeListener {
+    let notifyDidChange: (CanvasElementProtocol) -> Void
 }
 
 extension CanvasElementProtocol {
@@ -28,7 +28,7 @@ extension CanvasElementProtocol {
 
     func notifyObservers() {
         observers.forEach {
-            $0.notifyDidChange(newObj: self)
+            $0.notifyDidChange(self)
         }
     }
 }

--- a/Dynavity/Dynavity/model/canvas/elements/CodeElement.swift
+++ b/Dynavity/Dynavity/model/canvas/elements/CodeElement.swift
@@ -14,6 +14,7 @@ struct CodeElement: TextElementProtocol {
     var minimumHeight: CGFloat {
         60.0
     }
+    var observers = [ElementChangeListener]()
 
     // MARK: TextElementProtocol
     var text: String = ""
@@ -103,5 +104,11 @@ struct CodeElement: TextElementProtocol {
             processed = processed.replacingOccurrences(of: $0.0, with: $0.1)
         }
         self.text = processed
+    }
+}
+
+extension CodeElement: Codable {
+    private enum CodingKeys: CodingKey {
+        case id, position, width, height, rotation, text, language
     }
 }

--- a/Dynavity/Dynavity/model/canvas/elements/CodeElement.swift
+++ b/Dynavity/Dynavity/model/canvas/elements/CodeElement.swift
@@ -17,10 +17,14 @@ struct CodeElement: TextElementProtocol {
     var observers = [ElementChangeListener]()
 
     // MARK: TextElementProtocol
-    var text: String = ""
+    var text: String = "" {
+        didSet { notifyObservers() }
+    }
 
     // MARK: CodeElement-specific attributes
-    var language = CodeLanguage.python
+    var language = CodeLanguage.python {
+        didSet { notifyObservers() }
+    }
 
     init(position: CGPoint) {
         self.position = position

--- a/Dynavity/Dynavity/model/canvas/elements/ImageElement.swift
+++ b/Dynavity/Dynavity/model/canvas/elements/ImageElement.swift
@@ -8,7 +8,9 @@ struct ImageElement: CanvasElementProtocol {
     var rotation: Double = .zero
     var observers = [ElementChangeListener]()
 
-    private var codeImage: CodableImage
+    private var codeImage: CodableImage {
+        didSet { notifyObservers() }
+    }
     var image: UIImage {
         codeImage.image
     }

--- a/Dynavity/Dynavity/model/canvas/elements/ImageElement.swift
+++ b/Dynavity/Dynavity/model/canvas/elements/ImageElement.swift
@@ -3,11 +3,12 @@ import SwiftUI
 struct ImageElement: CanvasElementProtocol {
     var id = UUID()
     var position: CGPoint
-    private var codeImage: CodableImage
     var width: CGFloat
     var height: CGFloat
     var rotation: Double = .zero
+    var observers = [ElementChangeListener]()
 
+    private var codeImage: CodableImage
     var image: UIImage {
         codeImage.image
     }
@@ -20,5 +21,8 @@ struct ImageElement: CanvasElementProtocol {
     }
 }
 
-// MARK: Equatable
-extension ImageElement: Equatable {}
+extension ImageElement: Codable {
+    private enum CodingKeys: CodingKey {
+        case id, position, width, height, rotation, codeImage
+    }
+}

--- a/Dynavity/Dynavity/model/canvas/elements/MarkupElement.swift
+++ b/Dynavity/Dynavity/model/canvas/elements/MarkupElement.swift
@@ -12,6 +12,7 @@ struct MarkupElement: TextElementProtocol {
     var width: CGFloat = 500.0
     var height: CGFloat = 500.0
     var rotation: Double = .zero
+    var observers = [ElementChangeListener]()
 
     // MARK: TextElementProtocol
     var text: String = ""
@@ -25,4 +26,14 @@ struct MarkupElement: TextElementProtocol {
     }
 }
 
-extension MarkupElement: Equatable {}
+extension MarkupElement: Codable {
+    private enum CodingKeys: CodingKey {
+        case id, position, width, height, rotation, text, markupType
+    }
+}
+
+extension MarkupElement: Equatable {
+    static func == (lhs: MarkupElement, rhs: MarkupElement) -> Bool {
+        lhs.checkId(rhs)
+    }
+}

--- a/Dynavity/Dynavity/model/canvas/elements/MarkupElement.swift
+++ b/Dynavity/Dynavity/model/canvas/elements/MarkupElement.swift
@@ -15,10 +15,14 @@ struct MarkupElement: TextElementProtocol {
     var observers = [ElementChangeListener]()
 
     // MARK: TextElementProtocol
-    var text: String = ""
+    var text: String = "" {
+        didSet { notifyObservers() }
+    }
 
     // MARK: MarkupElement-specific attributes
-    var markupType: MarkupType
+    var markupType: MarkupType {
+        didSet { notifyObservers() }
+    }
 
     init(position: CGPoint, markupType: MarkupType) {
         self.position = position

--- a/Dynavity/Dynavity/model/canvas/elements/PDFElement.swift
+++ b/Dynavity/Dynavity/model/canvas/elements/PDFElement.swift
@@ -3,11 +3,16 @@ import SwiftUI
 struct PDFElement: CanvasElementProtocol {
     var id = UUID()
     var position: CGPoint
-    var file: URL
     var width: CGFloat = 500.0
     var height: CGFloat = 500.0
     var rotation: Double = .zero
+    var observers = [ElementChangeListener]()
+
+    var file: URL
 }
 
-// MARK: Equatable
-extension PDFElement: Equatable {}
+extension PDFElement: Codable {
+    private enum CodingKeys: CodingKey {
+        case id, position, width, height, rotation, file
+    }
+}

--- a/Dynavity/Dynavity/model/canvas/elements/PDFElement.swift
+++ b/Dynavity/Dynavity/model/canvas/elements/PDFElement.swift
@@ -8,7 +8,9 @@ struct PDFElement: CanvasElementProtocol {
     var rotation: Double = .zero
     var observers = [ElementChangeListener]()
 
-    var file: URL
+    var file: URL {
+        didSet { notifyObservers() }
+    }
 }
 
 extension PDFElement: Codable {

--- a/Dynavity/Dynavity/model/canvas/elements/PlainTextElement.swift
+++ b/Dynavity/Dynavity/model/canvas/elements/PlainTextElement.swift
@@ -11,7 +11,9 @@ struct PlainTextElement: TextElementProtocol {
     var observers = [ElementChangeListener]()
 
     // MARK: TextElementProtocol
-    var text: String = ""
+    var text: String = "" {
+        didSet { notifyObservers() }
+    }
 }
 
 extension PlainTextElement: Codable {

--- a/Dynavity/Dynavity/model/canvas/elements/PlainTextElement.swift
+++ b/Dynavity/Dynavity/model/canvas/elements/PlainTextElement.swift
@@ -2,16 +2,20 @@ import CoreGraphics
 import Foundation
 
 struct PlainTextElement: TextElementProtocol {
-    // TODO: Replace these with actual values
     // MARK: CanvasElementProtocol
     var id = UUID()
     var position: CGPoint
     var width: CGFloat = 500.0
     var height: CGFloat = 500.0
     var rotation: Double = .zero
+    var observers = [ElementChangeListener]()
 
     // MARK: TextElementProtocol
     var text: String = ""
 }
 
-extension PlainTextElement: Equatable {}
+extension PlainTextElement: Codable {
+    private enum CodingKeys: CodingKey {
+        case id, position, width, height, rotation, text
+    }
+}

--- a/Dynavity/Dynavity/model/canvas/elements/TodoElement.swift
+++ b/Dynavity/Dynavity/model/canvas/elements/TodoElement.swift
@@ -20,10 +20,12 @@ struct TodoElement: CanvasElementProtocol {
 
     mutating func removeTodo(at index: Int) {
         todos.remove(at: index)
+        notifyObservers()
     }
 
     mutating func addTodo(label: String) {
         todos.append(Todo(label: label))
+        notifyObservers()
     }
 }
 

--- a/Dynavity/Dynavity/model/canvas/elements/TodoElement.swift
+++ b/Dynavity/Dynavity/model/canvas/elements/TodoElement.swift
@@ -13,6 +13,7 @@ struct TodoElement: CanvasElementProtocol {
     var minimumHeight: CGFloat {
         60.0
     }
+    var observers = [ElementChangeListener]()
 
     // MARK: TodosElement-specific attributes
     var todos: [Todo] = []

--- a/Dynavity/Dynavity/model/canvas/elements/uml-shapes/DiamondUmlElement.swift
+++ b/Dynavity/Dynavity/model/canvas/elements/uml-shapes/DiamondUmlElement.swift
@@ -16,7 +16,9 @@ struct DiamondUmlElement: UmlElementProtocol {
     var observers = [ElementChangeListener]()
 
     // MARK: UmlElementProtocol
-    var label: String = "Decision"
+    var label: String = "Decision" {
+        didSet { notifyObservers() }
+    }
     var umlType: UmlType = .activityDiagram
     var umlShape: UmlShape = .diamond
 }

--- a/Dynavity/Dynavity/model/canvas/elements/uml-shapes/DiamondUmlElement.swift
+++ b/Dynavity/Dynavity/model/canvas/elements/uml-shapes/DiamondUmlElement.swift
@@ -13,9 +13,16 @@ struct DiamondUmlElement: UmlElementProtocol {
     var minimumHeight: CGFloat {
         60.0
     }
+    var observers = [ElementChangeListener]()
 
     // MARK: UmlElementProtocol
     var label: String = "Decision"
     var umlType: UmlType = .activityDiagram
     var umlShape: UmlShape = .diamond
+}
+
+extension DiamondUmlElement: Codable {
+    private enum CodingKeys: CodingKey {
+        case id, position, width, height, rotation, label, umlType, umlShape
+    }
 }

--- a/Dynavity/Dynavity/model/canvas/elements/uml-shapes/RectangleUmlElement.swift
+++ b/Dynavity/Dynavity/model/canvas/elements/uml-shapes/RectangleUmlElement.swift
@@ -13,9 +13,16 @@ struct RectangleUmlElement: UmlElementProtocol {
     var minimumHeight: CGFloat {
         60.0
     }
+    var observers = [ElementChangeListener]()
 
     // MARK: UmlElementProtocol
     var label: String = "Process"
     var umlType: UmlType = .activityDiagram
     var umlShape: UmlShape = .rectangle
+}
+
+extension RectangleUmlElement: Codable {
+    private enum CodingKeys: CodingKey {
+        case id, position, width, height, rotation, label, umlType, umlShape
+    }
 }

--- a/Dynavity/Dynavity/model/canvas/elements/uml-shapes/RectangleUmlElement.swift
+++ b/Dynavity/Dynavity/model/canvas/elements/uml-shapes/RectangleUmlElement.swift
@@ -16,7 +16,9 @@ struct RectangleUmlElement: UmlElementProtocol {
     var observers = [ElementChangeListener]()
 
     // MARK: UmlElementProtocol
-    var label: String = "Process"
+    var label: String = "Process" {
+        didSet { notifyObservers() }
+    }
     var umlType: UmlType = .activityDiagram
     var umlShape: UmlShape = .rectangle
 }

--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
@@ -95,7 +95,15 @@ class CanvasViewModel: ObservableObject {
     }
 
     var elementObserver: ElementChangeListener {
-        ElementChangeListener { newValue in
+        ElementChangeListener { element in
+            var newValue = element
+            if let oldValue = self.canvas.getElementBy(id: newValue.id) {
+                // use the existing position, height, width, rotation
+                newValue.position = oldValue.position
+                newValue.height = oldValue.height
+                newValue.width = oldValue.width
+                newValue.rotation = oldValue.rotation
+            }
             self.canvas.replaceElement(newValue)
         }
     }

--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
@@ -93,6 +93,18 @@ class CanvasViewModel: ObservableObject {
     func setCanvasViewport(size: CGSize) {
         canvasViewport = size
     }
+
+    var elementObserver: ElementChangeListener {
+        ElementChangeListener { newValue in
+            self.canvas.replaceElement(newValue)
+        }
+    }
+
+    func addObserver(element: CanvasElementProtocol) -> CanvasElementProtocol {
+        var observedElement = element
+        observedElement.addObserver(elementObserver)
+        return observedElement
+    }
 }
 
 // MARK: Firebase synchronization
@@ -119,6 +131,7 @@ extension CanvasViewModel {
                    let selectedCanvasElement = self.canvas.getElementBy(id: id) {
                     loadedCanvas.replaceElement(selectedCanvasElement)
                 }
+                loadedCanvas.canvasElements = loadedCanvas.canvasElements.map(self.addObserver)
                 self.canvas = loadedCanvas
                 self.enableWriteBack = true
             }
@@ -133,30 +146,34 @@ extension CanvasViewModel {
 
 // MARK: Adding of canvas elements
 extension CanvasViewModel {
+    func addElement(_ element: CanvasElementProtocol) {
+        canvas.addElement(addObserver(element: element))
+    }
+
     func addImageElement(from image: UIImage) {
         let imageCanvasElement = ImageElement(position: canvasCenter, image: image)
-        canvas.addElement(imageCanvasElement)
+        addElement(imageCanvasElement)
     }
 
     func addPdfElement(from file: URL) {
         let pdfCanvasElement = PDFElement(position: canvasCenter, file: file)
-        canvas.addElement(pdfCanvasElement)
+        addElement(pdfCanvasElement)
     }
 
     func addTodoElement() {
-        canvas.addElement(TodoElement(position: canvasCenter))
+        addElement(TodoElement(position: canvasCenter))
     }
 
     func addPlainTextElement() {
-        canvas.addElement(PlainTextElement(position: canvasCenter))
+        addElement(PlainTextElement(position: canvasCenter))
     }
 
     func addCodeElement() {
-        canvas.addElement(CodeElement(position: canvasCenter))
+        addElement(CodeElement(position: canvasCenter))
     }
 
     func addMarkupElement(markupType: MarkupElement.MarkupType) {
-        canvas.addElement(MarkupElement(position: canvasCenter, markupType: markupType))
+        addElement(MarkupElement(position: canvasCenter, markupType: markupType))
     }
 
     func storeAnnotation(_ drawing: PKDrawing) {
@@ -167,9 +184,9 @@ extension CanvasViewModel {
         // TODO: Apply factory pattern here
         switch umlElement.umlShape {
         case .diamond:
-            canvas.addElement(DiamondUmlElement(position: canvasCenter))
+            addElement(DiamondUmlElement(position: canvasCenter))
         case .rectangle:
-            canvas.addElement(RectangleUmlElement(position: canvasCenter))
+            addElement(RectangleUmlElement(position: canvasCenter))
         }
     }
 }


### PR DESCRIPTION
Observer pattern is set up in `CanvasElementProtocol` to listen for changes in element-specific properties.

Property changes are now correctly reflected on Firebase, but I'm having some trouble with displaying the changes once received.

There's also a weird issue where the elements in `canvasElements` have the latest `position`, `width`, `height`, and `rotation`, but the element-level objects do not. Hence during the observer notification the "new value" contains stale information. I've devised a workaround that uses the `position`, `width`, `height`, and `rotation` information from `canvasElements` instead, which works for now but we should probably investigate why it is happening and fix the root cause.

---

The received changes cannot be updated because each canvas element has its own view model, which has its own value-type model struct. This cannot be easily fixed, so this PR can be merged as-is for now.