### PR TITLE
Refactor uml connectors to a UmlConnectorView

### DIFF
--- a/Dynavity/Dynavity/view/CanvasElementMapView.swift
+++ b/Dynavity/Dynavity/view/CanvasElementMapView.swift
@@ -3,56 +3,19 @@ import SwiftUI
 struct CanvasElementMapView: View {
     @ObservedObject var viewModel: CanvasViewModel
     private let elementViewFactory = CanvasElementViewFactory()
-    private let umlConnectorLineWidth: CGFloat = 1.0
-    private let umlConnectorLineColor: Color = .black
-    private let umlConnectorHitboxWidth: CGFloat = 20.0
-    private let umlConnectorHitboxOpacity: Double = 0.001
 
     private func isSelected(_ element: CanvasElementProtocol) -> Bool {
         viewModel.selectedCanvasElementId == element.id
-    }
-
-    private func isSelected(umlConnector: UmlConnector) -> Bool {
-        viewModel.selectedUmlConnectorId == umlConnector.id
     }
 
     private func shouldShowUmlSelectionOverlay(_ element: CanvasElementProtocol) -> Bool {
         element is UmlElementProtocol && (viewModel.umlConnectorStart != nil || isSelected(element))
     }
 
-    private func generatePathFromPoints(_ pathPoints: [CGPoint]) -> Path {
-        var points = pathPoints
-        return Path { path in
-            let origin = points.removeFirst()
-            // Translate point to account of CanvasView offset
-            path.move(to: origin - viewModel.canvasOrigin + viewModel.canvasViewport / 2.0)
-            points.forEach {
-                path.addLine(to: $0 - viewModel.canvasOrigin + viewModel.canvasViewport / 2.0)
-            }
-        }
-    }
-
-    private func generateUmlConnectors(_ connector: UmlConnector) -> some View {
-        let points = connector.points
-        let path = generatePathFromPoints(points)
-            .stroke(umlConnectorLineColor, lineWidth: umlConnectorLineWidth)
-            .overlay(isSelected(umlConnector: connector)
-                        ? ConnectorSelectionOverlayView(connector: connector, viewModel: viewModel)
-                        : nil)
-
-        let pathHitbox = generatePathFromPoints(points)
-            // Prevent hitbox from covering other connectors, yet allow it to detect touches
-            .stroke(Color.white.opacity(umlConnectorHitboxOpacity), lineWidth: umlConnectorHitboxWidth)
-
-        return pathHitbox
-            .overlay(path)
-            .offset(x: viewModel.canvasOrigin.x, y: viewModel.canvasOrigin.y)
-    }
-
     var body: some View {
         ZStack {
             ForEach(viewModel.getCanvasUmlConnectors(), id: \.id) { connector in
-                generateUmlConnectors(connector)
+                UmlConnectorView(viewModel: viewModel, connector: connector)
                     .onTapGesture {
                         viewModel.select(umlConnector: connector)
                     }

--- a/Dynavity/Dynavity/view/UmlConnectorView.swift
+++ b/Dynavity/Dynavity/view/UmlConnectorView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+struct UmlConnectorView: View {
+    @ObservedObject var viewModel: CanvasViewModel
+    var connector: UmlConnector
+
+    private let umlConnectorLineWidth: CGFloat = 1.0
+    private let umlConnectorLineColor: Color = .black
+    private let umlConnectorHitboxWidth: CGFloat = 20.0
+    private let umlConnectorHitboxOpacity: Double = 0.001
+
+    private func isSelected(umlConnector: UmlConnector) -> Bool {
+        viewModel.selectedUmlConnectorId == umlConnector.id
+    }
+
+    private func generatePathFromPoints(_ pathPoints: [CGPoint]) -> Path {
+        var points = pathPoints
+        return Path { path in
+            let origin = points.removeFirst()
+            // Translate point to account of CanvasView offset
+            path.move(to: origin - viewModel.canvasOrigin + viewModel.canvasViewport / 2.0)
+            points.forEach {
+                path.addLine(to: $0 - viewModel.canvasOrigin + viewModel.canvasViewport / 2.0)
+            }
+        }
+    }
+
+    var body: some View {
+        let points = connector.points
+        let path = generatePathFromPoints(points)
+            .stroke(umlConnectorLineColor, lineWidth: umlConnectorLineWidth)
+            .overlay(isSelected(umlConnector: connector)
+                        ? ConnectorSelectionOverlayView(connector: connector, viewModel: viewModel)
+                        : nil)
+
+        let pathHitbox = generatePathFromPoints(points)
+            // Prevent hitbox from covering other connectors, yet allow it to detect touches
+            .stroke(Color.white.opacity(umlConnectorHitboxOpacity), lineWidth: umlConnectorHitboxWidth)
+
+        return pathHitbox
+            .overlay(path)
+            .offset(x: viewModel.canvasOrigin.x, y: viewModel.canvasOrigin.y)
+    }
+}
+
+struct UmlConnectorView_Previews: PreviewProvider {
+    @ObservedObject static var viewModel = CanvasViewModel()
+    static var previews: some View {
+        let connector = UmlConnector(points: [],
+                                     connects: (fromElement: UUID(), toElement: UUID()),
+                                     connectingSide: (fromSide: ConnectorConnectingSide.middleRight,
+                                                      toSide: ConnectorConnectingSide.middleLeft))
+        UmlConnectorView(viewModel: viewModel, connector: connector)
+    }
+}


### PR DESCRIPTION
Realized that when drawing the class diagram for Dynavity's View representation, UmlConnectors don't have their own View. As such I have added a `UmlConnectorView` to represent UmlConnectors, instead of using `Path`s in `CanvasElementMapView`