### PR TITLE
Fix unselecting a canvas element not clearing UML overlay

### DIFF
--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
@@ -178,8 +178,7 @@ extension CanvasViewModel {
 extension CanvasViewModel {
     func select(canvasElement: CanvasElementProtocol) {
         if selectedCanvasElementId == canvasElement.id {
-            selectedCanvasElementId = nil
-            umlConnectorStart = nil
+            unselectCanvasElement()
             return
         }
         selectedCanvasElementId = canvasElement.id
@@ -187,6 +186,7 @@ extension CanvasViewModel {
 
     func unselectCanvasElement() {
         selectedCanvasElementId = nil
+        umlConnectorStart = nil
     }
 
     func moveSelectedCanvasElement(by translation: CGSize) {


### PR DESCRIPTION
Previously, tapping on a plus button of `UMLSelectionOverlayView`, then deselecting the canvas element by tapping on the background of the canvas did not clear all of the plus buttons.