### PR TITLE
Defer quote autocorrect until runtime

### DIFF
--- a/Dynavity/Dynavity/view-model/canvas/elements/CodeElementViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/elements/CodeElementViewModel.swift
@@ -13,6 +13,7 @@ class CodeElementViewModel: ObservableObject {
     }
 
     func runCode() {
+        convertQuotes()
         let program = codeElement.text
         guard !program.isEmpty else {
             // backend will not accept an empty program

--- a/Dynavity/Dynavity/view/canvas/elements/CodeElementView.swift
+++ b/Dynavity/Dynavity/view/canvas/elements/CodeElementView.swift
@@ -22,9 +22,6 @@ struct CodeElementView: View {
                 .font(.custom("Courier", size: viewModel.codeElement.fontSize))
                 .autocapitalization(.none)
                 .disableAutocorrection(true)
-                .onChange(of: viewModel.codeElement.text) {_ in
-                    viewModel.convertQuotes()
-                }
             Divider()
             HStack {
                 Picker("Language", selection: $viewModel.codeElement.language) {


### PR DESCRIPTION
Previously when quotes such as `“` and `‘` are typed, they were previously immediately autocorrected to `"` and `'`. However, this has the unintended side effect of resetting the text cursor.

The autocorrection is now deferred until the code actually needs to be run.