### PR TITLE
Refactor UmlConnectors from struct to class

### DIFF
--- a/Dynavity/Dynavity/model/canvas/Canvas.swift
+++ b/Dynavity/Dynavity/model/canvas/Canvas.swift
@@ -7,6 +7,7 @@ class Canvas: ObservableObject {
     @Published private(set) var umlConnectors: [UmlConnector] = []
     var name: String = "common"
     private var canvasElementCancellables: [AnyCancellable] = []
+    private var umlConnectorCancellables: [AnyCancellable] = []
 
     func addElement(_ element: CanvasElementProtocol) {
         canvasElements.append(element)
@@ -30,6 +31,10 @@ class Canvas: ObservableObject {
 extension Canvas {
     func addUmlConnector(_ connector: UmlConnector) {
         umlConnectors.append(connector)
+        let cancellable = connector.objectWillChange.sink { [weak self] _ in
+            self?.objectWillChange.send()
+        }
+        umlConnectorCancellables.append(cancellable)
     }
 
     func removeUmlConnector(_ connector: UmlConnector) {
@@ -37,7 +42,7 @@ extension Canvas {
             return
         }
         umlConnectors.remove(at: index)
-
+        umlConnectorCancellables.remove(at: index)
     }
 }
 

--- a/Dynavity/Dynavity/model/canvas/Canvas.swift
+++ b/Dynavity/Dynavity/model/canvas/Canvas.swift
@@ -32,20 +32,12 @@ extension Canvas {
         umlConnectors.append(connector)
     }
 
-    func replaceUmlConnector(_ connector: UmlConnector) {
-        guard let index = umlConnectors.firstIndex(where: { $0.id == connector.id }) else {
-            return
-        }
-
-        umlConnectors[index] = connector
-    }
-
     func removeUmlConnector(_ connector: UmlConnector) {
-        guard let index = umlConnectors.firstIndex(where: { $0.id == connector.id }) else {
+        guard let index = umlConnectors.firstIndex(where: { $0 === connector }) else {
             return
         }
-
         umlConnectors.remove(at: index)
+
     }
 }
 

--- a/Dynavity/Dynavity/model/canvas/UmlConnector.swift
+++ b/Dynavity/Dynavity/model/canvas/UmlConnector.swift
@@ -4,24 +4,20 @@ import CoreGraphics
 /**
  Encapsulates a connector between two UML shapes.
  */
-struct UmlConnector {
-    // TODO: Should this be updated to not use ID as well?
-    var id: UUID
+class UmlConnector: Identifiable {
     var points: [CGPoint]
-    // UUID of UmlElementProtocol, actual element is in [CanvasElementProtocol] in Canvas
     var connects: (fromElement: UmlElementProtocol, toElement: UmlElementProtocol)
     var connectingSide: (fromSide: ConnectorConnectingSide, toSide: ConnectorConnectingSide)
 
     init(points: [CGPoint],
          connects: (fromElement: UmlElementProtocol, toElement: UmlElementProtocol),
          connectingSide: (fromSide: ConnectorConnectingSide, toSide: ConnectorConnectingSide)) {
-        self.id = UUID()
         self.points = points
         self.connects = connects
         self.connectingSide = connectingSide
     }
 
-    mutating func addPoint(_ point: CGPoint) {
+    func addPoint(_ point: CGPoint) {
         points.append(point)
     }
 }

--- a/Dynavity/Dynavity/model/canvas/UmlConnector.swift
+++ b/Dynavity/Dynavity/model/canvas/UmlConnector.swift
@@ -1,10 +1,13 @@
 import Foundation
 import CoreGraphics
+import Combine
 
 /**
  Encapsulates a connector between two UML shapes.
  */
-class UmlConnector: Identifiable {
+class UmlConnector: Identifiable, AnyObservableObject {
+    var objectWillChange: ObservableObjectPublisher
+
     var points: [CGPoint]
     var connects: (fromElement: UmlElementProtocol, toElement: UmlElementProtocol)
     var connectingSide: (fromSide: ConnectorConnectingSide, toSide: ConnectorConnectingSide)
@@ -15,6 +18,7 @@ class UmlConnector: Identifiable {
         self.points = points
         self.connects = connects
         self.connectingSide = connectingSide
+        self.objectWillChange = ObservableObjectPublisher()
     }
 
     func addPoint(_ point: CGPoint) {

--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel+Uml.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel+Uml.swift
@@ -48,13 +48,11 @@ extension CanvasViewModel {
     }
 
     func updateUmlConnections(element: UmlElementProtocol) {
-        var idsToRemove: [UUID] = []
-        for var connector in canvas.umlConnectors {
+        for connector in canvas.umlConnectors {
             if connector.connects.fromElement !== element
                     && connector.connects.toElement !== element {
                 continue
             }
-            idsToRemove.append(connector.id)
             let sourceElement = connector.connects.fromElement
             let destElement = connector.connects.toElement
             let sourceAnchor = connector.connectingSide.fromSide
@@ -62,7 +60,6 @@ extension CanvasViewModel {
             let newPoints = OrthogonalConnector(from: sourceElement, to: destElement)
                 .generateRoute(sourceAnchor, destAnchor: destAnchor)
             connector.points = newPoints
-            canvas.replaceUmlConnector(connector)
         }
     }
 }
@@ -96,11 +93,11 @@ extension CanvasViewModel {
 // MARK: UML connector gestures
 extension CanvasViewModel {
     func select(umlConnector: UmlConnector) {
-        if selectedUmlConnectorId == umlConnector.id {
-            selectedUmlConnectorId = nil
+        if selectedUmlConnector != nil {
+            selectedUmlConnector = nil
             return
         }
-        selectedUmlConnectorId = umlConnector.id
+        selectedUmlConnector = umlConnector
     }
 
     func removeUmlConnector(_ connector: UmlConnector) {

--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
@@ -44,7 +44,7 @@ class CanvasViewModel: ObservableObject {
     @Published var shouldShowUmlMenu = false
 
     // Uml element connectors
-    @Published var selectedUmlConnectorId: UUID?
+    @Published var selectedUmlConnector: UmlConnector?
     @Published var umlConnectorStart: (umlElement: UmlElementProtocol, anchor: ConnectorConnectingSide)?
     @Published var umlConnectorEnd: (umlElement: UmlElementProtocol, anchor: ConnectorConnectingSide)?
     var canvasViewport: CGSize = .zero

--- a/Dynavity/Dynavity/view/CanvasElementMapView.swift
+++ b/Dynavity/Dynavity/view/CanvasElementMapView.swift
@@ -14,7 +14,7 @@ struct CanvasElementMapView: View {
 
     var body: some View {
         ZStack {
-            ForEach(viewModel.getCanvasUmlConnectors(), id: \.id) { connector in
+            ForEach(viewModel.getCanvasUmlConnectors()) { connector in
                 UmlConnectorView(viewModel: viewModel, connector: connector)
                     .onTapGesture {
                         viewModel.select(umlConnector: connector)

--- a/Dynavity/Dynavity/view/UmlConnectorView.swift
+++ b/Dynavity/Dynavity/view/UmlConnectorView.swift
@@ -10,7 +10,7 @@ struct UmlConnectorView: View {
     private let umlConnectorHitboxOpacity: Double = 0.001
 
     private func isSelected(umlConnector: UmlConnector) -> Bool {
-        viewModel.selectedUmlConnectorId == umlConnector.id
+        viewModel.selectedUmlConnector === umlConnector
     }
 
     private func generatePathFromPoints(_ pathPoints: [CGPoint]) -> Path {


### PR DESCRIPTION
Known issues include connections drawing being off when `UmlElement` is rotated and resized. However I think this is not a big issue since it was mentioned that UI does not matter.

![IMG_3C2B0335199B-1](https://user-images.githubusercontent.com/24553546/114228482-0eb1fb00-99a9-11eb-8352-d6a7dad9e445.jpeg)
