### PR TITLE
Fix behaviour when selecting canvas elements & UML connectors

### DIFF
--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel+Uml.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel+Uml.swift
@@ -93,7 +93,7 @@ extension CanvasViewModel {
 // MARK: UML connector gestures
 extension CanvasViewModel {
     func select(umlConnector: UmlConnector) {
-        if selectedUmlConnector != nil {
+        if selectedUmlConnector === umlConnector {
             selectedUmlConnector = nil
             return
         }

--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
@@ -31,7 +31,13 @@ class CanvasViewModel: ObservableObject {
     @Published var canvasSize: CGFloat
     @Published var canvasTopLeftOffset: CGPoint = .zero
     @Published var scaleFactor: CGFloat = 1.0
-    @Published var selectedCanvasElement: CanvasElementProtocol?
+    @Published var selectedCanvasElement: CanvasElementProtocol? {
+        didSet {
+            if selectedCanvasElement != nil {
+                selectedUmlConnector = nil
+            }
+        }
+    }
     @Published var canvasMode: CanvasMode {
         didSet {
             // Reset canvas element selection on selecting some other mode.
@@ -44,7 +50,13 @@ class CanvasViewModel: ObservableObject {
     @Published var shouldShowUmlMenu = false
 
     // Uml element connectors
-    @Published var selectedUmlConnector: UmlConnector?
+    @Published var selectedUmlConnector: UmlConnector? {
+        didSet {
+            if selectedUmlConnector != nil {
+                selectedCanvasElement = nil
+            }
+        }
+    }
     @Published var umlConnectorStart: (umlElement: UmlElementProtocol, anchor: ConnectorConnectingSide)?
     @Published var umlConnectorEnd: (umlElement: UmlElementProtocol, anchor: ConnectorConnectingSide)?
     var canvasViewport: CGSize = .zero

--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
@@ -186,7 +186,7 @@ extension CanvasViewModel {
 // MARK: Editing/deleting of canvas elements
 extension CanvasViewModel {
     func select(canvasElement: CanvasElementProtocol) {
-        if selectedCanvasElement != nil {
+        if selectedCanvasElement === canvasElement {
             unselectCanvasElement()
             return
         }


### PR DESCRIPTION
Fixes the issue highlighted in https://github.com/Dynavity/dynavity/pull/66#discussion_r610989089.

Also updated the behaviour to enforce only one selection across all canvas elements and UML connectors. Previously, canvas element selections and UML connector selections were distinct.