### PR TITLE
Add persistence for UML elements and connectors

### DIFF
--- a/Dynavity/Dynavity/persistence/data-mapping/CanvasDTO.swift
+++ b/Dynavity/Dynavity/persistence/data-mapping/CanvasDTO.swift
@@ -3,13 +3,17 @@ import Foundation
 struct CanvasDTO: Mappable {
     var id: UUID
     let canvasElements: [TypeWrappedCanvasElementDTO]
-    // TODO: add umlconnectors
+    let umlConnectors: [UmlConnectorDTO]
     let name: String
 
     init(id: UUID, model: Canvas) {
         self.id = id
         self.name = model.name
-        self.canvasElements = model.canvasElements.map({ TypeWrappedCanvasElementDTO(model: $0) })
+        let canvasElementDTOs = model.canvasElements.map({ TypeWrappedCanvasElementDTO(model: $0) })
+        self.canvasElements = canvasElementDTOs
+        self.umlConnectors = model.umlConnectors.map({ UmlConnectorDTO(model: $0,
+                                                                       canvasElementDTOs: canvasElementDTOs,
+                                                                       canvasElements: model.canvasElements) })
     }
 
     init(model: Canvas) {
@@ -21,6 +25,10 @@ struct CanvasDTO: Mappable {
         model.name = name
         for ele in canvasElements {
             model.addElement(ele.toModel())
+        }
+        for uml in umlConnectors {
+            model.addUmlConnector(uml.toModel(canvasElementDTOs: canvasElements,
+                                              canvasElements: model.canvasElements))
         }
         return model
     }

--- a/Dynavity/Dynavity/persistence/data-mapping/UmlConnectorDTO.swift
+++ b/Dynavity/Dynavity/persistence/data-mapping/UmlConnectorDTO.swift
@@ -1,0 +1,50 @@
+import CoreGraphics
+import Foundation
+
+struct UmlConnectorDTO {
+    let points: [CGPoint]
+    let connectsFromId: UUID
+    let connectsToId: UUID
+    let connectingSideFrom: String
+    let connectingSideTo: String
+
+    init(
+        model: UmlConnector,
+        canvasElementDTOs: [TypeWrappedCanvasElementDTO],
+        canvasElements: [CanvasElementProtocol]
+    ) {
+        guard let connectsFromIndex = canvasElements.firstIndex(where: { $0 === model.connects.fromElement }),
+              let connectsToIndex = canvasElements.firstIndex(where: { $0 === model.connects.toElement }),
+              let connectsFrom = canvasElementDTOs[connectsFromIndex].data as? UmlElementProtocolDTO,
+              let connectsTo = canvasElementDTOs[connectsToIndex].data as? UmlElementProtocolDTO else {
+            fatalError("Failed to serialise UmlConnector")
+        }
+        self.points = model.points
+        self.connectsFromId = connectsFrom.id
+        self.connectsToId = connectsTo.id
+        self.connectingSideFrom = model.connectingSide.fromSide.rawValue
+        self.connectingSideTo = model.connectingSide.toSide.rawValue
+    }
+
+    func toModel(
+        canvasElementDTOs: [TypeWrappedCanvasElementDTO],
+        canvasElements: [CanvasElementProtocol]
+    ) -> UmlConnector {
+        guard let connectsFromIndex =
+                canvasElementDTOs.firstIndex(where: { connectsFromId == ($0.data as? UmlElementProtocolDTO)?.id }),
+              let connectsToIndex =
+                canvasElementDTOs.firstIndex(where: { connectsToId == ($0.data as? UmlElementProtocolDTO)?.id }),
+              let connectsFrom = canvasElements[connectsFromIndex] as? UmlElementProtocol,
+              let connectsTo = canvasElements[connectsToIndex] as? UmlElementProtocol,
+              let fromSide = ConnectorConnectingSide(rawValue: connectingSideFrom),
+              let toSide = ConnectorConnectingSide(rawValue: connectingSideTo) else {
+            fatalError("Failed to deserialise UmlConnector")
+        }
+        let connectingSide = (fromSide: fromSide, toSide: toSide)
+        let connects = (fromElement: connectsFrom, toElement: connectsTo)
+        let model = UmlConnector(points: points, connects: connects, connectingSide: connectingSide)
+        return model
+    }
+}
+
+extension UmlConnectorDTO: Codable {}

--- a/Dynavity/Dynavity/persistence/data-mapping/elements/TypeWrappedCanvasElementDTO.swift
+++ b/Dynavity/Dynavity/persistence/data-mapping/elements/TypeWrappedCanvasElementDTO.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-// TODO: complete this with uml DTOs
 enum TypeWrappedCanvasElementDTO: Mappable {
     case image(ImageElementDTO)
     case pdf(PDFElementDTO)
@@ -9,7 +8,7 @@ enum TypeWrappedCanvasElementDTO: Mappable {
     case code(CodeElementDTO)
     case markup(MarkupElementDTO)
     case umlDiamond(DiamondUmlElementDTO)
-//    case umlRectangle(RectangleUmlElementDTO)
+    case umlRectangle(RectangleUmlElementDTO)
 
     enum ElementType: String {
         case image
@@ -19,7 +18,7 @@ enum TypeWrappedCanvasElementDTO: Mappable {
         case code
         case markup
         case umlDiamond
-//        case umlRectangle
+        case umlRectangle
     }
 
     var type: ElementType {
@@ -38,8 +37,8 @@ enum TypeWrappedCanvasElementDTO: Mappable {
             return .markup
         case .umlDiamond:
             return .umlDiamond
-//        case .umlRectangle:
-//            return .umlRectangle
+        case .umlRectangle:
+            return .umlRectangle
         }
     }
 
@@ -59,8 +58,8 @@ enum TypeWrappedCanvasElementDTO: Mappable {
             return data
         case .umlDiamond(let data):
             return data
-//        case .umlRectangle(let data):
-//            return data
+        case .umlRectangle(let data):
+            return data
         }
     }
 
@@ -80,8 +79,8 @@ enum TypeWrappedCanvasElementDTO: Mappable {
             return data.toModel()
         case .umlDiamond(let data):
             return data.toModel()
-//        case .umlRectangle(let data):
-//            return data
+        case .umlRectangle(let data):
+            return data.toModel()
         }
     }
 
@@ -102,8 +101,8 @@ enum TypeWrappedCanvasElementDTO: Mappable {
             self = .text(PlainTextElementDTO(model: plainTextElement))
         case let diamondUmlElement as DiamondUmlElement:
             self = .umlDiamond(DiamondUmlElementDTO(model: diamondUmlElement))
-//        case let rectangleUmlElement as RectangleUmlElement:
-//            self = .umlRectangle(rectangleUmlElement)
+        case let rectangleUmlElement as RectangleUmlElement:
+            self = .umlRectangle(RectangleUmlElementDTO(model: rectangleUmlElement))
         default:
             fatalError("Unknown type")
         }
@@ -141,8 +140,8 @@ extension TypeWrappedCanvasElementDTO: Codable {
             self = .markup(try decodeData(MarkupElementDTO.self))
         case .umlDiamond:
             self = .umlDiamond(try decodeData(DiamondUmlElementDTO.self))
-//        case .umlRectangle:
-//            self = .umlRectangle(try decodeData(RectangleUmlElement.self))
+        case .umlRectangle:
+            self = .umlRectangle(try decodeData(RectangleUmlElementDTO.self))
         case .none:
             fatalError("Unknown type")
         }
@@ -168,8 +167,8 @@ extension TypeWrappedCanvasElementDTO: Codable {
             try encodeData(data)
         case .umlDiamond(let data):
             try encodeData(data)
-//        case .umlRectangle(let data):
-//            try encodeData(data)
+        case .umlRectangle(let data):
+            try encodeData(data)
         }
         try container.encode(type.rawValue, forKey: .type)
     }

--- a/Dynavity/Dynavity/persistence/data-mapping/elements/TypeWrappedCanvasElementDTO.swift
+++ b/Dynavity/Dynavity/persistence/data-mapping/elements/TypeWrappedCanvasElementDTO.swift
@@ -8,7 +8,7 @@ enum TypeWrappedCanvasElementDTO: Mappable {
     case text(PlainTextElementDTO)
     case code(CodeElementDTO)
     case markup(MarkupElementDTO)
-//    case umlDiamond(DiamondUmlElementDTO)
+    case umlDiamond(DiamondUmlElementDTO)
 //    case umlRectangle(RectangleUmlElementDTO)
 
     enum ElementType: String {
@@ -18,7 +18,7 @@ enum TypeWrappedCanvasElementDTO: Mappable {
         case text
         case code
         case markup
-//        case umlDiamond
+        case umlDiamond
 //        case umlRectangle
     }
 
@@ -36,8 +36,8 @@ enum TypeWrappedCanvasElementDTO: Mappable {
             return .code
         case .markup:
             return .markup
-//        case .umlDiamond:
-//            return .umlDiamond
+        case .umlDiamond:
+            return .umlDiamond
 //        case .umlRectangle:
 //            return .umlRectangle
         }
@@ -57,8 +57,8 @@ enum TypeWrappedCanvasElementDTO: Mappable {
             return data
         case .markup(let data):
             return data
-//        case .umlDiamond(let data):
-//            return data
+        case .umlDiamond(let data):
+            return data
 //        case .umlRectangle(let data):
 //            return data
         }
@@ -78,8 +78,8 @@ enum TypeWrappedCanvasElementDTO: Mappable {
             return data.toModel()
         case .markup(let data):
             return data.toModel()
-//        case .umlDiamond(let data):
-//            return data
+        case .umlDiamond(let data):
+            return data.toModel()
 //        case .umlRectangle(let data):
 //            return data
         }
@@ -100,8 +100,8 @@ enum TypeWrappedCanvasElementDTO: Mappable {
         // Note: PlainTextElement must be checked after its subclassse
         case let plainTextElement as PlainTextElement:
             self = .text(PlainTextElementDTO(model: plainTextElement))
-//        case let diamondUmlElement as DiamondUmlElement:
-//            self = .umlDiamond(diamondUmlElement)
+        case let diamondUmlElement as DiamondUmlElement:
+            self = .umlDiamond(DiamondUmlElementDTO(model: diamondUmlElement))
 //        case let rectangleUmlElement as RectangleUmlElement:
 //            self = .umlRectangle(rectangleUmlElement)
         default:
@@ -139,8 +139,8 @@ extension TypeWrappedCanvasElementDTO: Codable {
             self = .code(try decodeData(CodeElementDTO.self))
         case .markup:
             self = .markup(try decodeData(MarkupElementDTO.self))
-//        case .umlDiamond:
-//            self = .umlDiamond(try decodeData(DiamondUmlElement.self))
+        case .umlDiamond:
+            self = .umlDiamond(try decodeData(DiamondUmlElementDTO.self))
 //        case .umlRectangle:
 //            self = .umlRectangle(try decodeData(RectangleUmlElement.self))
         case .none:
@@ -166,8 +166,8 @@ extension TypeWrappedCanvasElementDTO: Codable {
             try encodeData(data)
         case .markup(let data):
             try encodeData(data)
-//        case .umlDiamond(let data):
-//            try encodeData(data)
+        case .umlDiamond(let data):
+            try encodeData(data)
 //        case .umlRectangle(let data):
 //            try encodeData(data)
         }

--- a/Dynavity/Dynavity/persistence/data-mapping/elements/uml-shapes/DiamondUmlElementDTO.swift
+++ b/Dynavity/Dynavity/persistence/data-mapping/elements/uml-shapes/DiamondUmlElementDTO.swift
@@ -9,7 +9,7 @@ struct DiamondUmlElementDTO: CanvasElementProtocolDTO, Mappable {
         self.canvasProperties = CanvasElementPropertiesDTO(model: model.canvasProperties)
         self.label = model.label
         self.umlType = model.umlType.rawValue
-        self.umlShape = model.umlType.rawValue
+        self.umlShape = model.umlShape.rawValue
     }
 
     func toModel() -> DiamondUmlElement {

--- a/Dynavity/Dynavity/persistence/data-mapping/elements/uml-shapes/DiamondUmlElementDTO.swift
+++ b/Dynavity/Dynavity/persistence/data-mapping/elements/uml-shapes/DiamondUmlElementDTO.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct DiamondUmlElementDTO: CanvasElementProtocolDTO, Mappable {
+struct DiamondUmlElementDTO: UmlElementProtocolDTO, Mappable {
     // For storing UML connectors
     let id: UUID
 

--- a/Dynavity/Dynavity/persistence/data-mapping/elements/uml-shapes/DiamondUmlElementDTO.swift
+++ b/Dynavity/Dynavity/persistence/data-mapping/elements/uml-shapes/DiamondUmlElementDTO.swift
@@ -1,0 +1,27 @@
+struct DiamondUmlElementDTO: CanvasElementProtocolDTO, Mappable {
+    let canvasProperties: CanvasElementPropertiesDTO
+
+    let label: String
+    let umlType: String
+    let umlShape: String
+
+    init(model: DiamondUmlElement) {
+        self.canvasProperties = CanvasElementPropertiesDTO(model: model.canvasProperties)
+        self.label = model.label
+        self.umlType = model.umlType.rawValue
+        self.umlShape = model.umlType.rawValue
+    }
+
+    func toModel() -> DiamondUmlElement {
+        guard let umlType = UmlType(rawValue: self.umlType),
+              let umlShape = UmlShape(rawValue: self.umlShape) else {
+            fatalError("Failed to deserialise DiamondUmlElement")
+        }
+        let model = DiamondUmlElement(position: canvasProperties.position)
+        model.canvasProperties = canvasProperties.toModel()
+        model.label = label
+        model.umlType = umlType
+        model.umlShape = umlShape
+        return model
+    }
+}

--- a/Dynavity/Dynavity/persistence/data-mapping/elements/uml-shapes/DiamondUmlElementDTO.swift
+++ b/Dynavity/Dynavity/persistence/data-mapping/elements/uml-shapes/DiamondUmlElementDTO.swift
@@ -1,4 +1,9 @@
+import Foundation
+
 struct DiamondUmlElementDTO: CanvasElementProtocolDTO, Mappable {
+    // For storing UML connectors
+    let id: UUID
+
     let canvasProperties: CanvasElementPropertiesDTO
 
     let label: String
@@ -6,6 +11,7 @@ struct DiamondUmlElementDTO: CanvasElementProtocolDTO, Mappable {
     let umlShape: String
 
     init(model: DiamondUmlElement) {
+        self.id = UUID()
         self.canvasProperties = CanvasElementPropertiesDTO(model: model.canvasProperties)
         self.label = model.label
         self.umlType = model.umlType.rawValue

--- a/Dynavity/Dynavity/persistence/data-mapping/elements/uml-shapes/RectangleUmlElementDTO.swift
+++ b/Dynavity/Dynavity/persistence/data-mapping/elements/uml-shapes/RectangleUmlElementDTO.swift
@@ -1,0 +1,27 @@
+struct RectangleUmlElementDTO: CanvasElementProtocolDTO, Mappable {
+    let canvasProperties: CanvasElementPropertiesDTO
+
+    let label: String
+    let umlType: String
+    let umlShape: String
+
+    init(model: RectangleUmlElement) {
+        self.canvasProperties = CanvasElementPropertiesDTO(model: model.canvasProperties)
+        self.label = model.label
+        self.umlType = model.umlType.rawValue
+        self.umlShape = model.umlType.rawValue
+    }
+
+    func toModel() -> RectangleUmlElement {
+        guard let umlType = UmlType(rawValue: self.umlType),
+              let umlShape = UmlShape(rawValue: self.umlShape) else {
+            fatalError("Failed to deserialise RectangleUmlElement")
+        }
+        let model = RectangleUmlElement(position: canvasProperties.position)
+        model.canvasProperties = canvasProperties.toModel()
+        model.label = label
+        model.umlType = umlType
+        model.umlShape = umlShape
+        return model
+    }
+}

--- a/Dynavity/Dynavity/persistence/data-mapping/elements/uml-shapes/RectangleUmlElementDTO.swift
+++ b/Dynavity/Dynavity/persistence/data-mapping/elements/uml-shapes/RectangleUmlElementDTO.swift
@@ -1,4 +1,9 @@
+import Foundation
+
 struct RectangleUmlElementDTO: CanvasElementProtocolDTO, Mappable {
+    // For storing UML connectors
+    let id: UUID
+
     let canvasProperties: CanvasElementPropertiesDTO
 
     let label: String
@@ -6,6 +11,7 @@ struct RectangleUmlElementDTO: CanvasElementProtocolDTO, Mappable {
     let umlShape: String
 
     init(model: RectangleUmlElement) {
+        self.id = UUID()
         self.canvasProperties = CanvasElementPropertiesDTO(model: model.canvasProperties)
         self.label = model.label
         self.umlType = model.umlType.rawValue

--- a/Dynavity/Dynavity/persistence/data-mapping/elements/uml-shapes/RectangleUmlElementDTO.swift
+++ b/Dynavity/Dynavity/persistence/data-mapping/elements/uml-shapes/RectangleUmlElementDTO.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct RectangleUmlElementDTO: CanvasElementProtocolDTO, Mappable {
+struct RectangleUmlElementDTO: UmlElementProtocolDTO, Mappable {
     // For storing UML connectors
     let id: UUID
 

--- a/Dynavity/Dynavity/persistence/data-mapping/elements/uml-shapes/RectangleUmlElementDTO.swift
+++ b/Dynavity/Dynavity/persistence/data-mapping/elements/uml-shapes/RectangleUmlElementDTO.swift
@@ -9,7 +9,7 @@ struct RectangleUmlElementDTO: CanvasElementProtocolDTO, Mappable {
         self.canvasProperties = CanvasElementPropertiesDTO(model: model.canvasProperties)
         self.label = model.label
         self.umlType = model.umlType.rawValue
-        self.umlShape = model.umlType.rawValue
+        self.umlShape = model.umlShape.rawValue
     }
 
     func toModel() -> RectangleUmlElement {

--- a/Dynavity/Dynavity/persistence/data-mapping/elements/uml-shapes/UmlElementProtocolDTO.swift
+++ b/Dynavity/Dynavity/persistence/data-mapping/elements/uml-shapes/UmlElementProtocolDTO.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+protocol UmlElementProtocolDTO: CanvasElementProtocolDTO {
+    // For storing UML connectors
+    var id: UUID { get }
+}


### PR DESCRIPTION
The mess in `UmlConnectorDTO` is so that we can store the relationships between UML connectors and UML elements without having to add an `id` field to the model (which Prof Wai Kay hates). This way, the IDs only exist in the DTO layer, leaving the model layer untouched.

Note that on initial load, the UML connectors are incorrectly offset, but this doesn't seem to stem from the persistence layer which this PR is about.