### PR TITLE
Fix annotation menu interfering with canvas element interactions

### DIFF
--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
@@ -61,6 +61,10 @@ class CanvasViewModel: ObservableObject {
             if oldValue == .selection && canvasMode != oldValue {
                 selectedCanvasElement = nil
             }
+            // Reset annotation menu on changing mode.
+            if oldValue != canvasMode {
+                shouldShowAnnotationMenu = false
+            }
         }
     }
     @Published var shouldShowAnnotationMenu = false


### PR DESCRIPTION
To test:
* Click on the pen mode twice to bring up the annotation menu.
* Click on the canvas element mode.
* Try to interact with any canvas element.