### PR TITLE
Add storage of backlinks

### DIFF
--- a/Dynavity/Dynavity/DynavityApp.swift
+++ b/Dynavity/Dynavity/DynavityApp.swift
@@ -11,13 +11,11 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
 @main
 struct DynavityApp: App {
-    @StateObject var graphMapViewModel = GraphMapViewModel()
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
     var body: some Scene {
         WindowGroup {
             CanvasSelectionView()
-                .environmentObject(graphMapViewModel)
         }
     }
 }

--- a/Dynavity/Dynavity/backlink/BacklinkEdge.swift
+++ b/Dynavity/Dynavity/backlink/BacklinkEdge.swift
@@ -15,14 +15,14 @@ extension BacklinkEdge: Hashable {
         return sameSourceAndDest || sameButOpposite
     }
 
-    /// Arbitrarliy hash the node that has a "smaller" UUID first.
+    /// Arbitrarliy hash the node that has a "smaller" name first.
     /// This is so that we conform to Hashable's requirement:
     /// Two instances that are equal must feed the same values to Hasher in hash(into:), in the same order.
     func hash(into hasher: inout Hasher) {
-        let sourceStringUUID = source.id.uuidString
-        let destinationStringUUID = destination.id.uuidString
+        let sourceName = source.name
+        let destinationName = destination.name
 
-        if sourceStringUUID <= destinationStringUUID {
+        if sourceName <= destinationName {
             hasher.combine(source)
             hasher.combine(destination)
         } else {

--- a/Dynavity/Dynavity/backlink/BacklinkEngine.swift
+++ b/Dynavity/Dynavity/backlink/BacklinkEngine.swift
@@ -28,9 +28,8 @@ struct BacklinkEngine {
     }
 
     mutating func addNode(name: String) {
-        // TODO: figure out a way to position new nodes
-        let randomPoint = CGPoint(x: Int.random(in: -300...300),
-                                  y: Int.random(in: -300...300))
+        let randomPoint = CGPoint(x: Int.random(in: -500...500),
+                                  y: Int.random(in: -500...500))
         let node = BacklinkNode(name: name, position: randomPoint)
         graph.addNode(node)
     }

--- a/Dynavity/Dynavity/backlink/BacklinkEngine.swift
+++ b/Dynavity/Dynavity/backlink/BacklinkEngine.swift
@@ -35,11 +35,19 @@ struct BacklinkEngine {
         graph.addNode(node)
     }
 
+    mutating func addNode(node: BacklinkNode) {
+        graph.addNode(node)
+    }
+
     mutating func deleteNode(name: String) {
         guard let node = getBacklinkNodeWithName(name: name) else {
             return
         }
         graph.deleteNode(node)
+    }
+
+    mutating func addEdge(edge: BacklinkEdge) {
+        graph.addLinkBetween(edge.source, and: edge.destination)
     }
 
     mutating func addLinkBetween(_ firstItemName: String, and secondItemName: String) {

--- a/Dynavity/Dynavity/backlink/BacklinkEngine.swift
+++ b/Dynavity/Dynavity/backlink/BacklinkEngine.swift
@@ -35,6 +35,13 @@ struct BacklinkEngine {
         graph.addNode(node)
     }
 
+    mutating func deleteNode(name: String) {
+        guard let node = getBacklinkNodeWithName(name: name) else {
+            return
+        }
+        graph.deleteNode(node)
+    }
+
     mutating func addLinkBetween(_ firstItemName: String, and secondItemName: String) {
         guard let firstNode = getBacklinkNodeWithName(name: firstItemName),
               let secondNode = getBacklinkNodeWithName(name: secondItemName) else {

--- a/Dynavity/Dynavity/backlink/BacklinkEngine.swift
+++ b/Dynavity/Dynavity/backlink/BacklinkEngine.swift
@@ -46,6 +46,13 @@ struct BacklinkEngine {
         graph.deleteNode(node)
     }
 
+    mutating func renameNode(oldName: String, newName: String) {
+        guard let node = getBacklinkNodeWithName(name: oldName) else {
+            return
+        }
+        graph.renameNode(node, newName: newName)
+    }
+
     mutating func addEdge(edge: BacklinkEdge) {
         graph.addLinkBetween(edge.source, and: edge.destination)
     }

--- a/Dynavity/Dynavity/backlink/BacklinkEngine.swift
+++ b/Dynavity/Dynavity/backlink/BacklinkEngine.swift
@@ -5,7 +5,9 @@ import Foundation
 /// - Creation of backlinks between items
 /// - Retrieval of all backlinks for a particular item
 ///
-/// Items need not be homogeneous. The only requirement is that the items are wrapped in a `BacklinkNode`.
+/// Items need not be homogeneous.
+/// The only requirement is that the items are wrapped in a `BacklinkNode`
+/// and that the nodes are uniquely identified by their names.
 struct BacklinkEngine {
     private var graph: BacklinkGraph = Graph<BacklinkNode>(isDirected: false)
 
@@ -25,32 +27,32 @@ struct BacklinkEngine {
         return output
     }
 
-    mutating func addNode(id: UUID, name: String) {
+    mutating func addNode(name: String) {
         // TODO: figure out a way to position new nodes
         let randomPoint = CGPoint(x: Int.random(in: -300...300),
                                   y: Int.random(in: -300...300))
-        let node = BacklinkNode(id: id, name: name, position: randomPoint)
+        let node = BacklinkNode(name: name, position: randomPoint)
         graph.addNode(node)
     }
 
-    mutating func addLinkBetween(_ firstItemId: UUID, and secondItemId: UUID) {
-        guard let firstNode = getBacklinkNodeWithId(id: firstItemId),
-              let secondNode = getBacklinkNodeWithId(id: secondItemId) else {
+    mutating func addLinkBetween(_ firstItemName: String, and secondItemName: String) {
+        guard let firstNode = getBacklinkNodeWithName(name: firstItemName),
+              let secondNode = getBacklinkNodeWithName(name: secondItemName) else {
             return
         }
         graph.addLinkBetween(firstNode, and: secondNode)
     }
 
-    mutating func removeLinkBetween(_ firstItemId: UUID, and secondItemId: UUID) {
-        guard let firstNode = getBacklinkNodeWithId(id: firstItemId),
-              let secondNode = getBacklinkNodeWithId(id: secondItemId) else {
+    mutating func removeLinkBetween(_ firstItemName: String, and secondItemName: String) {
+        guard let firstNode = getBacklinkNodeWithName(name: firstItemName),
+              let secondNode = getBacklinkNodeWithName(name: secondItemName) else {
             return
         }
         graph.removeLinkBetween(firstNode, and: secondNode)
     }
 
-    func getBacklinks(for id: UUID) -> [BacklinkNode] {
-        guard let node = getBacklinkNodeWithId(id: id) else {
+    func getBacklinks(for name: String) -> [BacklinkNode] {
+        guard let node = getBacklinkNodeWithName(name: name) else {
             return []
         }
         return graph.getBacklinks(for: node)
@@ -60,7 +62,7 @@ struct BacklinkEngine {
         graph.moveBacklinkNode(backlinkNode, to: updatedPos)
     }
 
-    private func getBacklinkNodeWithId(id: UUID?) -> BacklinkNode? {
-        self.nodes.first(where: { $0.id == id })
+    private func getBacklinkNodeWithName(name: String) -> BacklinkNode? {
+        self.nodes.first(where: { $0.name == name })
     }
 }

--- a/Dynavity/Dynavity/backlink/BacklinkGraph.swift
+++ b/Dynavity/Dynavity/backlink/BacklinkGraph.swift
@@ -7,6 +7,7 @@ protocol BacklinkGraph {
     func getBacklinks(for item: BacklinkNode) -> [BacklinkNode]
     mutating func addNode(_ node: BacklinkNode)
     mutating func deleteNode(_ node: BacklinkNode)
+    mutating func renameNode(_ node: BacklinkNode, newName: String)
     mutating func addLinkBetween(_ firstItem: BacklinkNode, and secondItem: BacklinkNode)
     mutating func removeLinkBetween(_ firstItem: BacklinkNode, and secondItem: BacklinkNode)
     mutating func moveBacklinkNode(_ backlinkNode: BacklinkNode, to updatedPos: CGPoint)

--- a/Dynavity/Dynavity/backlink/BacklinkGraph.swift
+++ b/Dynavity/Dynavity/backlink/BacklinkGraph.swift
@@ -6,6 +6,7 @@ protocol BacklinkGraph {
 
     func getBacklinks(for item: BacklinkNode) -> [BacklinkNode]
     mutating func addNode(_ node: BacklinkNode)
+    mutating func deleteNode(_ node: BacklinkNode)
     mutating func addLinkBetween(_ firstItem: BacklinkNode, and secondItem: BacklinkNode)
     mutating func removeLinkBetween(_ firstItem: BacklinkNode, and secondItem: BacklinkNode)
     mutating func moveBacklinkNode(_ backlinkNode: BacklinkNode, to updatedPos: CGPoint)

--- a/Dynavity/Dynavity/backlink/BacklinkNode.swift
+++ b/Dynavity/Dynavity/backlink/BacklinkNode.swift
@@ -10,6 +10,10 @@ struct BacklinkNode {
         self.position = position
     }
 
+    func renaming(to newName: String) -> BacklinkNode {
+        BacklinkNode(name: newName, position: self.position)
+    }
+
     func moving(to updatedPos: CGPoint) -> BacklinkNode {
         BacklinkNode(name: self.name, position: updatedPos)
     }

--- a/Dynavity/Dynavity/backlink/BacklinkNode.swift
+++ b/Dynavity/Dynavity/backlink/BacklinkNode.swift
@@ -1,35 +1,26 @@
 import CoreGraphics
 import Foundation
 
-struct BacklinkNode: Identifiable {
-    let id: UUID
+struct BacklinkNode {
     let name: String
     var position: CGPoint
 
-    init(id: UUID, name: String, position: CGPoint) {
-        self.id = id
-        self.name = name
-        self.position = position
-    }
-
     init(name: String, position: CGPoint) {
-        self.init(id: UUID(), name: name, position: position)
+        self.init(name: name, position: position)
     }
 
     func moving(to updatedPos: CGPoint) -> BacklinkNode {
-        BacklinkNode(id: self.id, name: self.name, position: updatedPos)
+        BacklinkNode(name: self.name, position: updatedPos)
     }
 }
 
 extension BacklinkNode: Hashable {
-    // Equality based solely on id
+    // Equality based solely on name
     static func == (lhs: BacklinkNode, rhs: BacklinkNode) -> Bool {
-        lhs.id == rhs.id
+        lhs.name == rhs.name
     }
 
-    // TODO: check if there's a better way of doing this since this can cause issues with
-    // adjacency list implementation of graph
     func hash(into hasher: inout Hasher) {
-        hasher.combine(self.id)
+        hasher.combine(self.name)
     }
 }

--- a/Dynavity/Dynavity/backlink/BacklinkNode.swift
+++ b/Dynavity/Dynavity/backlink/BacklinkNode.swift
@@ -2,7 +2,7 @@ import CoreGraphics
 import Foundation
 
 struct BacklinkNode {
-    let name: String
+    var name: String
     var position: CGPoint
 
     init(name: String, position: CGPoint) {

--- a/Dynavity/Dynavity/backlink/BacklinkNode.swift
+++ b/Dynavity/Dynavity/backlink/BacklinkNode.swift
@@ -6,7 +6,8 @@ struct BacklinkNode {
     var position: CGPoint
 
     init(name: String, position: CGPoint) {
-        self.init(name: name, position: position)
+        self.name = name
+        self.position = position
     }
 
     func moving(to updatedPos: CGPoint) -> BacklinkNode {

--- a/Dynavity/Dynavity/backlink/Graph+BacklinkGraph.swift
+++ b/Dynavity/Dynavity/backlink/Graph+BacklinkGraph.swift
@@ -22,6 +22,10 @@ extension Graph: BacklinkGraph where T == BacklinkNode {
         self.addNode(Node(node))
     }
 
+    mutating func deleteNode(_ node: BacklinkNode) {
+        self.removeNode(Node(node))
+    }
+
     mutating func addLinkBetween(_ firstItem: BacklinkNode, and secondItem: BacklinkNode) {
         assert(!self.isDirected)
         let edge = createEdgeBetween(firstItem, and: secondItem)

--- a/Dynavity/Dynavity/backlink/Graph+BacklinkGraph.swift
+++ b/Dynavity/Dynavity/backlink/Graph+BacklinkGraph.swift
@@ -26,6 +26,15 @@ extension Graph: BacklinkGraph where T == BacklinkNode {
         self.removeNode(Node(node))
     }
 
+    mutating func renameNode(_ node: BacklinkNode, newName: String) {
+        guard let originalNode = getNodeWithName(name: node.name) else {
+            return
+        }
+
+        let updatedBacklinkNode = BacklinkNode(name: newName, position: node.position)
+        self.updateNode(originalNode, to: Node(updatedBacklinkNode))
+    }
+
     mutating func addLinkBetween(_ firstItem: BacklinkNode, and secondItem: BacklinkNode) {
         assert(!self.isDirected)
         let edge = createEdgeBetween(firstItem, and: secondItem)

--- a/Dynavity/Dynavity/backlink/Graph+BacklinkGraph.swift
+++ b/Dynavity/Dynavity/backlink/Graph+BacklinkGraph.swift
@@ -34,7 +34,7 @@ extension Graph: BacklinkGraph where T == BacklinkNode {
     }
 
     mutating func moveBacklinkNode(_ backlinkNode: BacklinkNode, to updatedPos: CGPoint) {
-        guard let originalNode = getNodeWithId(id: backlinkNode.id) else {
+        guard let originalNode = getNodeWithName(name: backlinkNode.name) else {
             return
         }
 
@@ -49,7 +49,7 @@ extension Graph: BacklinkGraph where T == BacklinkNode {
         return Edge(source: firstNode, destination: secondNode)
     }
 
-    private func getNodeWithId(id: UUID?) -> Node<BacklinkNode>? {
-        self.nodes.first(where: { $0.label.id == id })
+    private func getNodeWithName(name: String) -> Node<BacklinkNode>? {
+        self.nodes.first(where: { $0.label.name == name })
     }
 }

--- a/Dynavity/Dynavity/backlink/Graph+BacklinkGraph.swift
+++ b/Dynavity/Dynavity/backlink/Graph+BacklinkGraph.swift
@@ -31,7 +31,7 @@ extension Graph: BacklinkGraph where T == BacklinkNode {
             return
         }
 
-        let updatedBacklinkNode = BacklinkNode(name: newName, position: node.position)
+        let updatedBacklinkNode = originalNode.label.renaming(to: newName)
         self.updateNode(originalNode, to: Node(updatedBacklinkNode))
     }
 

--- a/Dynavity/Dynavity/persistence/data-mapping/backlink/BacklinkEngineDTO.swift
+++ b/Dynavity/Dynavity/persistence/data-mapping/backlink/BacklinkEngineDTO.swift
@@ -12,11 +12,11 @@ struct BacklinkEngineDTO: Mappable {
 
         for nodeDTO in backlinkNodes {
             let node = nodeDTO.toModel()
-            engine.addNode(id: node.id, name: node.name)
+            engine.addNode(name: node.name)
         }
         for edgeDTO in backlinkEdges {
             let edge = edgeDTO.toModel()
-            engine.addLinkBetween(edge.source.id, and: edge.destination.id)
+            engine.addLinkBetween(edge.source.name, and: edge.destination.name)
         }
 
         return engine

--- a/Dynavity/Dynavity/persistence/data-mapping/backlink/BacklinkEngineDTO.swift
+++ b/Dynavity/Dynavity/persistence/data-mapping/backlink/BacklinkEngineDTO.swift
@@ -12,11 +12,11 @@ struct BacklinkEngineDTO: Mappable {
 
         for nodeDTO in backlinkNodes {
             let node = nodeDTO.toModel()
-            engine.addNode(name: node.name)
+            engine.addNode(node: node)
         }
         for edgeDTO in backlinkEdges {
             let edge = edgeDTO.toModel()
-            engine.addLinkBetween(edge.source.name, and: edge.destination.name)
+            engine.addEdge(edge: edge)
         }
 
         return engine

--- a/Dynavity/Dynavity/persistence/data-mapping/backlink/BacklinkNodeDTO.swift
+++ b/Dynavity/Dynavity/persistence/data-mapping/backlink/BacklinkNodeDTO.swift
@@ -2,18 +2,16 @@ import CoreGraphics
 import Foundation
 
 struct BacklinkNodeDTO: Mappable {
-    let id: UUID
     let name: String
     let position: CGPoint
 
     init(model: BacklinkNode) {
-        self.id = model.id
         self.name = model.name
         self.position = model.position
     }
 
     func toModel() -> BacklinkNode {
-        BacklinkNode(id: id, name: name, position: position)
+        BacklinkNode(name: name, position: position)
     }
 }
 

--- a/Dynavity/Dynavity/persistence/repositories/BacklinkRepository.swift
+++ b/Dynavity/Dynavity/persistence/repositories/BacklinkRepository.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable unavailable_function
 // Certain functions are not implemented as there's no use case for them in our application at the moment
 struct BacklinkRepository: Repository {
     let storageManager: StorageManager = LocalStorageManager()
@@ -7,6 +6,7 @@ struct BacklinkRepository: Repository {
         [try? storageManager.readBacklinkEngine()].compactMap({ $0?.toModel() })
     }
 
+    @discardableResult
     func save(model: BacklinkEngine) -> Bool {
         let dto = BacklinkEngineDTO(model: model)
         do {

--- a/Dynavity/Dynavity/persistence/repositories/BacklinkRepository.swift
+++ b/Dynavity/Dynavity/persistence/repositories/BacklinkRepository.swift
@@ -1,0 +1,31 @@
+// swiftlint:disable unavailable_function
+// Certain functions are not implemented as there's no use case for them in our application at the moment
+struct BacklinkRepository: Repository {
+    let storageManager: StorageManager = LocalStorageManager()
+
+    func queryAll() -> [BacklinkEngine] {
+        [try? storageManager.readBacklinkEngine()].compactMap({ $0?.toModel() })
+    }
+
+    func save(model: BacklinkEngine) -> Bool {
+        let dto = BacklinkEngineDTO(model: model)
+        do {
+            try storageManager.saveBacklinkEngine(backlinkEngine: dto)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    func update(oldModel: BacklinkEngine, newModel: BacklinkEngine) -> Bool {
+        fatalError("Not yet implemented")
+    }
+
+    func delete(model: BacklinkEngine) -> Bool {
+        fatalError("Not yet implemented")
+    }
+
+    func deleteMany(models: [BacklinkEngine]) -> Bool {
+        fatalError("Not yet implemented")
+    }
+}

--- a/Dynavity/Dynavity/persistence/repositories/CanvasRepository.swift
+++ b/Dynavity/Dynavity/persistence/repositories/CanvasRepository.swift
@@ -1,8 +1,6 @@
 import Foundation
 
 struct CanvasRepository: Repository {
-    typealias T = Canvas
-
     let storageManager: StorageManager = LocalStorageManager()
 
     /// Canvases are sorted in ascending order based on their names (case-insensitive)

--- a/Dynavity/Dynavity/persistence/storage/StorageManager.swift
+++ b/Dynavity/Dynavity/persistence/storage/StorageManager.swift
@@ -2,4 +2,7 @@ protocol StorageManager {
     func readAllCanvases() throws -> [CanvasDTO]
     func saveCanvas(canvas: CanvasDTO) throws
     func deleteCanvas(canvas: CanvasDTO) throws
+
+    func readBacklinkEngine() throws -> BacklinkEngineDTO?
+    func saveBacklinkEngine(backlinkEngine: BacklinkEngineDTO) throws
 }

--- a/Dynavity/Dynavity/view-model/CanvasSelectionViewModel.swift
+++ b/Dynavity/Dynavity/view-model/CanvasSelectionViewModel.swift
@@ -60,6 +60,10 @@ class CanvasSelectionViewModel: ObservableObject {
         !name.isEmpty && isCanvasNameUnique(name: name)
     }
 
+    func getCanvasWithName(name: String) -> Canvas? {
+        canvasRepo.queryAll().first(where: { $0.name == name })
+    }
+
     // Case-insensitive checking
     private func isCanvasNameUnique(name: String) -> Bool {
         !canvasRepo.queryAll().map({ $0.name.lowercased() }).contains(name.lowercased())

--- a/Dynavity/Dynavity/view-model/graph/GraphMapViewModel.swift
+++ b/Dynavity/Dynavity/view-model/graph/GraphMapViewModel.swift
@@ -2,9 +2,6 @@ import CoreGraphics
 import SwiftUI
 import Foundation
 
-// TODO: remove this once canvases are fully integrated
-let testCanvas = "COMMON"
-
 class GraphMapViewModel: ObservableObject {
     private let backlinkRepo = BacklinkRepository()
 
@@ -34,7 +31,6 @@ class GraphMapViewModel: ObservableObject {
 
     func getUnlinkedNodes(for name: String) -> [BacklinkNode] {
         let unlinkedNodes = Set(self.getNodes()).subtracting(self.getLinkedNodes(for: name))
-
         return Array(unlinkedNodes)
             // Exclude the input node
             .filter({ $0.name != name })

--- a/Dynavity/Dynavity/view-model/graph/GraphMapViewModel.swift
+++ b/Dynavity/Dynavity/view-model/graph/GraphMapViewModel.swift
@@ -47,6 +47,11 @@ class GraphMapViewModel: ObservableObject {
         backlinkRepo.save(model: backlinkEngine)
     }
 
+    func renameNode(oldName: String, newName: String) {
+        backlinkEngine.renameNode(oldName: oldName, newName: newName)
+        backlinkRepo.save(model: backlinkEngine)
+    }
+
     func deleteNodes(names: [String]) {
         for name in names {
             backlinkEngine.deleteNode(name: name)
@@ -91,6 +96,7 @@ extension GraphMapViewModel {
         processNodeTranslation(translation: value.translation, viewportZoomScale: viewportZoomScale)
         draggedNodeOriginalPosition = nil
         draggedNode = nil
+        backlinkRepo.save(model: backlinkEngine)
     }
 
     private func processNodeTranslation(translation: CGSize, viewportZoomScale: CGFloat) {

--- a/Dynavity/Dynavity/view-model/graph/GraphMapViewModel.swift
+++ b/Dynavity/Dynavity/view-model/graph/GraphMapViewModel.swift
@@ -51,6 +51,13 @@ class GraphMapViewModel: ObservableObject {
         backlinkRepo.save(model: backlinkEngine)
     }
 
+    func deleteNodes(names: [String]) {
+        for name in names {
+            backlinkEngine.deleteNode(name: name)
+        }
+        backlinkRepo.save(model: backlinkEngine)
+    }
+
     func addLinkBetween(_ firstItemName: String, and secondItemName: String) {
         backlinkEngine.addLinkBetween(firstItemName, and: secondItemName)
         backlinkRepo.save(model: backlinkEngine)

--- a/Dynavity/Dynavity/view-model/graph/GraphMapViewModel.swift
+++ b/Dynavity/Dynavity/view-model/graph/GraphMapViewModel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import Foundation
 
 // TODO: remove this once canvases are fully integrated
-let testId = UUID()
+let testCanvas = "COMMON"
 
 class GraphMapViewModel: ObservableObject {
     private let backlinkRepo = BacklinkRepository()
@@ -28,26 +28,26 @@ class GraphMapViewModel: ObservableObject {
         backlinkEngine.edges
     }
 
-    func getLinkedNodes(for id: UUID) -> [BacklinkNode] {
-        backlinkEngine.getBacklinks(for: id).sorted(by: { $0.name < $1.name })
+    func getLinkedNodes(for name: String) -> [BacklinkNode] {
+        backlinkEngine.getBacklinks(for: name).sorted(by: { $0.name < $1.name })
     }
 
-    func getUnlinkedNodes(for id: UUID) -> [BacklinkNode] {
-        let unlinkedNodes = Set(self.getNodes()).subtracting(self.getLinkedNodes(for: id))
+    func getUnlinkedNodes(for name: String) -> [BacklinkNode] {
+        let unlinkedNodes = Set(self.getNodes()).subtracting(self.getLinkedNodes(for: name))
 
         return Array(unlinkedNodes)
             // Exclude the input node
-            .filter({ $0.id != id })
+            .filter({ $0.name != name })
             .sorted(by: { $0.name < $1.name })
     }
 
-    func addLinkBetween(_ firstItemId: UUID, and secondItemId: UUID) {
-        backlinkEngine.addLinkBetween(firstItemId, and: secondItemId)
+    func addLinkBetween(_ firstItemName: String, and secondItemName: String) {
+        backlinkEngine.addLinkBetween(firstItemName, and: secondItemName)
         backlinkRepo.save(model: backlinkEngine)
     }
 
-    func removeLinkBetween(_ firstItemId: UUID, and secondItemId: UUID) {
-        backlinkEngine.removeLinkBetween(firstItemId, and: secondItemId)
+    func removeLinkBetween(_ firstItemName: String, and secondItemName: String) {
+        backlinkEngine.removeLinkBetween(firstItemName, and: secondItemName)
         backlinkRepo.save(model: backlinkEngine)
     }
 }

--- a/Dynavity/Dynavity/view-model/graph/GraphMapViewModel.swift
+++ b/Dynavity/Dynavity/view-model/graph/GraphMapViewModel.swift
@@ -2,6 +2,7 @@ import CoreGraphics
 import SwiftUI
 import Foundation
 
+// TODO: rename this to graphviewmodel
 class GraphMapViewModel: ObservableObject {
     private let backlinkRepo = BacklinkRepository()
 

--- a/Dynavity/Dynavity/view-model/graph/GraphMapViewModel.swift
+++ b/Dynavity/Dynavity/view-model/graph/GraphMapViewModel.swift
@@ -41,6 +41,16 @@ class GraphMapViewModel: ObservableObject {
             .sorted(by: { $0.name < $1.name })
     }
 
+    func addNode(name: String) {
+        backlinkEngine.addNode(name: name)
+        backlinkRepo.save(model: backlinkEngine)
+    }
+
+    func deleteNode(name: String) {
+        backlinkEngine.deleteNode(name: name)
+        backlinkRepo.save(model: backlinkEngine)
+    }
+
     func addLinkBetween(_ firstItemName: String, and secondItemName: String) {
         backlinkEngine.addLinkBetween(firstItemName, and: secondItemName)
         backlinkRepo.save(model: backlinkEngine)

--- a/Dynavity/Dynavity/view-model/graph/GraphMapViewModel.swift
+++ b/Dynavity/Dynavity/view-model/graph/GraphMapViewModel.swift
@@ -43,10 +43,12 @@ class GraphMapViewModel: ObservableObject {
 
     func addLinkBetween(_ firstItemId: UUID, and secondItemId: UUID) {
         backlinkEngine.addLinkBetween(firstItemId, and: secondItemId)
+        backlinkRepo.save(model: backlinkEngine)
     }
 
     func removeLinkBetween(_ firstItemId: UUID, and secondItemId: UUID) {
         backlinkEngine.removeLinkBetween(firstItemId, and: secondItemId)
+        backlinkRepo.save(model: backlinkEngine)
     }
 }
 

--- a/Dynavity/Dynavity/view-model/graph/GraphMapViewModel.swift
+++ b/Dynavity/Dynavity/view-model/graph/GraphMapViewModel.swift
@@ -6,7 +6,9 @@ import Foundation
 let testId = UUID()
 
 class GraphMapViewModel: ObservableObject {
-    @Published var backlinkEngine = BacklinkEngine()
+    private let backlinkRepo = BacklinkRepository()
+
+    @Published var backlinkEngine: BacklinkEngine
 
     private var draggedNodeOriginalPosition: CGPoint?
     @Published var draggedNode: BacklinkNode?
@@ -14,7 +16,8 @@ class GraphMapViewModel: ObservableObject {
     @Published var longPressedNode: BacklinkNode?
 
     init() {
-        initialiseBacklinkEngine()
+        let backlinkEngine = backlinkRepo.queryAll().first ?? BacklinkEngine()
+        self.backlinkEngine = backlinkEngine
     }
 
     func getNodes() -> [BacklinkNode] {
@@ -23,21 +26,6 @@ class GraphMapViewModel: ObservableObject {
 
     func getEdges() -> [BacklinkEdge] {
         backlinkEngine.edges
-    }
-
-    // TODO: replace the implementation of this function: load from file and rebuild the links
-    private func initialiseBacklinkEngine() {
-        backlinkEngine.addNode(id: testId, name: "TEST")
-
-        let ids: [UUID] = (0..<20).map({ _ in UUID() })
-        for id in ids {
-            backlinkEngine.addNode(id: id, name: id.uuidString)
-        }
-
-        for i in 0..<ids.endIndex - 1 {
-            backlinkEngine.addLinkBetween(testId, and: ids[i])
-            backlinkEngine.addLinkBetween(ids[i], and: ids[i + 1])
-        }
     }
 
     func getLinkedNodes(for id: UUID) -> [BacklinkNode] {

--- a/Dynavity/Dynavity/view-model/graph/GraphViewModel.swift
+++ b/Dynavity/Dynavity/view-model/graph/GraphViewModel.swift
@@ -2,7 +2,6 @@ import CoreGraphics
 import SwiftUI
 import Foundation
 
-// TODO: rename this to graphviewmodel
 class GraphViewModel: ObservableObject {
     private let backlinkRepo = BacklinkRepository()
 

--- a/Dynavity/Dynavity/view-model/graph/GraphViewModel.swift
+++ b/Dynavity/Dynavity/view-model/graph/GraphViewModel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import Foundation
 
 // TODO: rename this to graphviewmodel
-class GraphMapViewModel: ObservableObject {
+class GraphViewModel: ObservableObject {
     private let backlinkRepo = BacklinkRepository()
 
     @Published var backlinkEngine: BacklinkEngine
@@ -72,7 +72,7 @@ class GraphMapViewModel: ObservableObject {
 }
 
 // MARK: Node Dragging Handling
-extension GraphMapViewModel {
+extension GraphViewModel {
     func hitTest(tapPos: CGPoint, viewportSize: CGSize,
                  viewportZoomScale: CGFloat, viewportOriginOffset: CGPoint) {
         for node in self.getNodes() {

--- a/Dynavity/Dynavity/view/CanvasSelectionView.swift
+++ b/Dynavity/Dynavity/view/CanvasSelectionView.swift
@@ -178,7 +178,6 @@ extension CanvasSelectionView {
                                       preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "Delete", style: .destructive, handler: { _ in
             viewModel.deleteCanvas(canvas)
-            toggleEditMode()
         }))
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
         self.showAlert(alert: alert)
@@ -190,6 +189,7 @@ extension CanvasSelectionView {
                                       preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "Delete", style: .destructive, handler: { _ in
             viewModel.deleteSelectedCanvases()
+            toggleEditMode()
         }))
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
         self.showAlert(alert: alert)

--- a/Dynavity/Dynavity/view/CanvasSelectionView.swift
+++ b/Dynavity/Dynavity/view/CanvasSelectionView.swift
@@ -7,6 +7,7 @@ struct CanvasSelectionView: View {
     }
 
     @StateObject private var viewModel = CanvasSelectionViewModel()
+    @EnvironmentObject var graphMapViewModel: GraphMapViewModel
     @State private var isEditing = false
     @State private var selectionMode: SelectionMode = .grid
 
@@ -119,7 +120,6 @@ struct CanvasSelectionView: View {
                     }
                 }
                 SearchBarView(text: $viewModel.searchQuery)
-                // TODO: Implement saving the newly created canvas to state & db
                 selectionModeToggleButton
 
                 Button(action: {
@@ -178,6 +178,7 @@ extension CanvasSelectionView {
                                       preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "Delete", style: .destructive, handler: { _ in
             viewModel.deleteCanvas(canvas)
+            graphMapViewModel.deleteNode(name: canvas.name)
         }))
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
         self.showAlert(alert: alert)
@@ -209,6 +210,7 @@ extension CanvasSelectionView {
 
             if isNewNameUnique {
                 viewModel.createCanvas(name: updatedName)
+                graphMapViewModel.addNode(name: updatedName)
             } else {
                 invalidCanvasNameHandler()
             }

--- a/Dynavity/Dynavity/view/CanvasSelectionView.swift
+++ b/Dynavity/Dynavity/view/CanvasSelectionView.swift
@@ -164,6 +164,7 @@ extension CanvasSelectionView {
 
             if isNewNameUnique {
                 viewModel.renameCanvas(canvas, updatedName: updatedName)
+                graphMapViewModel.renameNode(oldName: canvas.name, newName: updatedName)
             } else {
                 invalidCanvasNameHandler()
             }

--- a/Dynavity/Dynavity/view/CanvasSelectionView.swift
+++ b/Dynavity/Dynavity/view/CanvasSelectionView.swift
@@ -7,7 +7,7 @@ struct CanvasSelectionView: View {
     }
 
     @StateObject private var viewModel = CanvasSelectionViewModel()
-    @StateObject var graphMapViewModel = GraphMapViewModel()
+    @StateObject var graphViewModel = GraphViewModel()
     @State private var isEditing = false
     @State private var selectionMode: SelectionMode = .grid
 
@@ -39,7 +39,7 @@ struct CanvasSelectionView: View {
             .navigationBarHidden(true)
         }
         .navigationViewStyle(StackNavigationViewStyle())
-        .environmentObject(graphMapViewModel)
+        .environmentObject(graphViewModel)
     }
 
     private var canvasesGrid: some View {
@@ -165,7 +165,7 @@ extension CanvasSelectionView {
 
             if isNewNameUnique {
                 viewModel.renameCanvas(canvas, updatedName: updatedName)
-                graphMapViewModel.renameNode(oldName: canvas.name, newName: updatedName)
+                graphViewModel.renameNode(oldName: canvas.name, newName: updatedName)
             } else {
                 invalidCanvasNameHandler()
             }
@@ -180,7 +180,7 @@ extension CanvasSelectionView {
                                       preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "Delete", style: .destructive, handler: { _ in
             viewModel.deleteCanvas(canvas)
-            graphMapViewModel.deleteNode(name: canvas.name)
+            graphViewModel.deleteNode(name: canvas.name)
         }))
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
         self.showAlert(alert: alert)
@@ -192,7 +192,7 @@ extension CanvasSelectionView {
                                       preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "Delete", style: .destructive, handler: { _ in
             viewModel.deleteSelectedCanvases()
-            graphMapViewModel.deleteNodes(names: viewModel.selectedCanvases.map({ $0.name }))
+            graphViewModel.deleteNodes(names: viewModel.selectedCanvases.map({ $0.name }))
             toggleEditMode()
         }))
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
@@ -213,7 +213,7 @@ extension CanvasSelectionView {
 
             if isNewNameUnique {
                 viewModel.createCanvas(name: updatedName)
-                graphMapViewModel.addNode(name: updatedName)
+                graphViewModel.addNode(name: updatedName)
             } else {
                 invalidCanvasNameHandler()
             }

--- a/Dynavity/Dynavity/view/CanvasSelectionView.swift
+++ b/Dynavity/Dynavity/view/CanvasSelectionView.swift
@@ -7,7 +7,7 @@ struct CanvasSelectionView: View {
     }
 
     @StateObject private var viewModel = CanvasSelectionViewModel()
-    @EnvironmentObject var graphMapViewModel: GraphMapViewModel
+    @StateObject var graphMapViewModel = GraphMapViewModel()
     @State private var isEditing = false
     @State private var selectionMode: SelectionMode = .grid
 
@@ -33,12 +33,13 @@ struct CanvasSelectionView: View {
                         canvasesGrid
                     }
                 case .graph:
-                    GraphView(searchQuery: $viewModel.searchQuery)
+                    GraphView(canvasSelectionViewModel: viewModel, searchQuery: $viewModel.searchQuery)
                 }
             }
             .navigationBarHidden(true)
         }
         .navigationViewStyle(StackNavigationViewStyle())
+        .environmentObject(graphMapViewModel)
     }
 
     private var canvasesGrid: some View {

--- a/Dynavity/Dynavity/view/CanvasSelectionView.swift
+++ b/Dynavity/Dynavity/view/CanvasSelectionView.swift
@@ -190,6 +190,7 @@ extension CanvasSelectionView {
                                       preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "Delete", style: .destructive, handler: { _ in
             viewModel.deleteSelectedCanvases()
+            graphMapViewModel.deleteNodes(names: viewModel.selectedCanvases.map({ $0.name }))
             toggleEditMode()
         }))
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))

--- a/Dynavity/Dynavity/view/SideMenuView.swift
+++ b/Dynavity/Dynavity/view/SideMenuView.swift
@@ -33,12 +33,12 @@ struct SideMenuView: View {
         Group {
             SideMenuHeaderView(headerText: "Backlinks")
             SideMenuContentView(label: "Linked Canvases") {
-                MultiSelectListView(nodes: graphMapViewModel.getLinkedNodes(for: testId),
+                MultiSelectListView(nodes: graphMapViewModel.getLinkedNodes(for: testCanvas),
                                     selections: $sideMenuViewModel.selectedLinkedNodes)
             }
             upDownButtons
             SideMenuContentView(label: "Unlinked Canvases") {
-                MultiSelectListView(nodes: graphMapViewModel.getUnlinkedNodes(for: testId),
+                MultiSelectListView(nodes: graphMapViewModel.getUnlinkedNodes(for: testCanvas),
                                     selections: $sideMenuViewModel.selectedUnlinkedNodes)
             }
         }
@@ -74,14 +74,14 @@ struct SideMenuView: View {
 extension SideMenuView {
     private func linkSelectedUnlinkedCanvases() {
         for unlinkedNode in sideMenuViewModel.selectedUnlinkedNodes {
-            graphMapViewModel.addLinkBetween(testId, and: unlinkedNode.id)
+            graphMapViewModel.addLinkBetween(testCanvas, and: unlinkedNode.name)
         }
         sideMenuViewModel.selectedUnlinkedNodes = []
     }
 
     private func unlinkSelectedLinkedCanvases() {
         for linkedNode in sideMenuViewModel.selectedLinkedNodes {
-            graphMapViewModel.removeLinkBetween(testId, and: linkedNode.id)
+            graphMapViewModel.removeLinkBetween(testCanvas, and: linkedNode.name)
         }
         sideMenuViewModel.selectedLinkedNodes = []
     }

--- a/Dynavity/Dynavity/view/SideMenuView.swift
+++ b/Dynavity/Dynavity/view/SideMenuView.swift
@@ -33,12 +33,12 @@ struct SideMenuView: View {
         Group {
             SideMenuHeaderView(headerText: "Backlinks")
             SideMenuContentView(label: "Linked Canvases") {
-                MultiSelectListView(nodes: graphMapViewModel.getLinkedNodes(for: testCanvas),
+                MultiSelectListView(nodes: graphMapViewModel.getLinkedNodes(for: canvasName),
                                     selections: $sideMenuViewModel.selectedLinkedNodes)
             }
             upDownButtons
             SideMenuContentView(label: "Unlinked Canvases") {
-                MultiSelectListView(nodes: graphMapViewModel.getUnlinkedNodes(for: testCanvas),
+                MultiSelectListView(nodes: graphMapViewModel.getUnlinkedNodes(for: canvasName),
                                     selections: $sideMenuViewModel.selectedUnlinkedNodes)
             }
         }
@@ -74,14 +74,14 @@ struct SideMenuView: View {
 extension SideMenuView {
     private func linkSelectedUnlinkedCanvases() {
         for unlinkedNode in sideMenuViewModel.selectedUnlinkedNodes {
-            graphMapViewModel.addLinkBetween(testCanvas, and: unlinkedNode.name)
+            graphMapViewModel.addLinkBetween(canvasName, and: unlinkedNode.name)
         }
         sideMenuViewModel.selectedUnlinkedNodes = []
     }
 
     private func unlinkSelectedLinkedCanvases() {
         for linkedNode in sideMenuViewModel.selectedLinkedNodes {
-            graphMapViewModel.removeLinkBetween(testCanvas, and: linkedNode.name)
+            graphMapViewModel.removeLinkBetween(canvasName, and: linkedNode.name)
         }
         sideMenuViewModel.selectedLinkedNodes = []
     }

--- a/Dynavity/Dynavity/view/SideMenuView.swift
+++ b/Dynavity/Dynavity/view/SideMenuView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct SideMenuView: View {
-    @EnvironmentObject var graphMapViewModel: GraphMapViewModel
+    @EnvironmentObject var graphViewModel: GraphViewModel
 
     var canvasName: String
 
@@ -33,12 +33,12 @@ struct SideMenuView: View {
         Group {
             SideMenuHeaderView(headerText: "Backlinks")
             SideMenuContentView(label: "Linked Canvases") {
-                MultiSelectListView(nodes: graphMapViewModel.getLinkedNodes(for: canvasName),
+                MultiSelectListView(nodes: graphViewModel.getLinkedNodes(for: canvasName),
                                     selections: $sideMenuViewModel.selectedLinkedNodes)
             }
             upDownButtons
             SideMenuContentView(label: "Unlinked Canvases") {
-                MultiSelectListView(nodes: graphMapViewModel.getUnlinkedNodes(for: canvasName),
+                MultiSelectListView(nodes: graphViewModel.getUnlinkedNodes(for: canvasName),
                                     selections: $sideMenuViewModel.selectedUnlinkedNodes)
             }
         }
@@ -74,14 +74,14 @@ struct SideMenuView: View {
 extension SideMenuView {
     private func linkSelectedUnlinkedCanvases() {
         for unlinkedNode in sideMenuViewModel.selectedUnlinkedNodes {
-            graphMapViewModel.addLinkBetween(canvasName, and: unlinkedNode.name)
+            graphViewModel.addLinkBetween(canvasName, and: unlinkedNode.name)
         }
         sideMenuViewModel.selectedUnlinkedNodes = []
     }
 
     private func unlinkSelectedLinkedCanvases() {
         for linkedNode in sideMenuViewModel.selectedLinkedNodes {
-            graphMapViewModel.removeLinkBetween(canvasName, and: linkedNode.name)
+            graphViewModel.removeLinkBetween(canvasName, and: linkedNode.name)
         }
         sideMenuViewModel.selectedLinkedNodes = []
     }
@@ -120,6 +120,6 @@ struct SideMenuContentView<Content: View>: View {
 struct SideMenuView_Previews: PreviewProvider {
     static var previews: some View {
         SideMenuView(canvasName: "Cool Name")
-            .environmentObject(GraphMapViewModel())
+            .environmentObject(GraphViewModel())
     }
 }

--- a/Dynavity/Dynavity/view/elements/MarkupElementView.swift
+++ b/Dynavity/Dynavity/view/elements/MarkupElementView.swift
@@ -3,10 +3,6 @@ import SwiftUI
 struct MarkupElementView: View {
     @StateObject private var viewModel: MarkupElementViewModel
 
-    // TODO: This is set to "selected" for now.
-    // The parent view containing this view should probably implement the logic for view selection.
-    // Purpose of having this state is so that when the view is not selected, the text editor will not show
-    @State private var isViewSelected = true
 
     init(markupElement: MarkupElement) {
         self._viewModel = StateObject(wrappedValue:
@@ -15,12 +11,9 @@ struct MarkupElementView: View {
 
     var body: some View {
         HStack {
-            if isViewSelected {
-                TextEditor(text: $viewModel.markupElement.text)
-                    .font(.custom("Custom", size: viewModel.markupElement.fontSize))
-                Divider()
-            }
-
+            TextEditor(text: $viewModel.markupElement.text)
+                .font(.system(size: viewModel.markupElement.fontSize))
+            Divider()
             WebView(bodyHtmlContent: viewModel.rawHtml)
         }
         .padding()

--- a/Dynavity/Dynavity/view/elements/MarkupElementView.swift
+++ b/Dynavity/Dynavity/view/elements/MarkupElementView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct MarkupElementView: View {
     @StateObject private var viewModel: MarkupElementViewModel
 
-
     init(markupElement: MarkupElement) {
         self._viewModel = StateObject(wrappedValue:
                                         MarkupElementViewModel(markupElement: markupElement))

--- a/Dynavity/Dynavity/view/graph/GraphView.swift
+++ b/Dynavity/Dynavity/view/graph/GraphView.swift
@@ -4,6 +4,7 @@ struct GraphView: View {
     private static let zoomScaleRange: ClosedRange<CGFloat> = 0.05...2.5
 
     @EnvironmentObject var viewModel: GraphMapViewModel
+    @ObservedObject var canvasSelectionViewModel: CanvasSelectionViewModel
 
     // For viewport dragging gesture
     @State var originOffset: CGPoint = .zero
@@ -46,9 +47,10 @@ struct GraphView: View {
                     // Solution referenced from https://stackoverflow.com/a/65401199
                     // If the current node has been long pressed, it means that we want to automatically
                     // navigate to the canvas corresponding to the long pressed node
-                    if viewModel.longPressedNode == node {
+                    if viewModel.longPressedNode == node,
+                       let canvas = canvasSelectionViewModel.getCanvasWithName(name: node.name) {
                         // TODO: pass in the relevant canvas into MainView
-                        NavigationLink(destination: MainView()
+                        NavigationLink(destination: MainView(canvas: canvas)
                                         .navigationBarHidden(true)
                                         .navigationBarBackButtonHidden(true),
                                        isActive: .constant(true)) {
@@ -131,7 +133,7 @@ extension GraphView {
 
 struct GraphView_Previews: PreviewProvider {
     static var previews: some View {
-        GraphView(searchQuery: .constant("Hello"))
+        GraphView(canvasSelectionViewModel: CanvasSelectionViewModel(), searchQuery: .constant("Hello"))
             .environmentObject(GraphMapViewModel())
     }
 }

--- a/Dynavity/Dynavity/view/graph/GraphView.swift
+++ b/Dynavity/Dynavity/view/graph/GraphView.swift
@@ -49,7 +49,6 @@ struct GraphView: View {
                     // navigate to the canvas corresponding to the long pressed node
                     if viewModel.longPressedNode == node,
                        let canvas = canvasSelectionViewModel.getCanvasWithName(name: node.name) {
-                        // TODO: pass in the relevant canvas into MainView
                         NavigationLink(destination: MainView(canvas: canvas)
                                         .navigationBarHidden(true)
                                         .navigationBarBackButtonHidden(true),

--- a/Dynavity/Dynavity/view/graph/GraphView.swift
+++ b/Dynavity/Dynavity/view/graph/GraphView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct GraphView: View {
-    private static let zoomScaleRange: ClosedRange<CGFloat> = 0.2...2.5
+    private static let zoomScaleRange: ClosedRange<CGFloat> = 0.05...2.5
 
     @EnvironmentObject var viewModel: GraphMapViewModel
 
@@ -18,7 +18,7 @@ struct GraphView: View {
     var body: some View {
         GeometryReader { geometry in
             ZStack {
-                Rectangle().fill(Color.UI.background)
+                Rectangle().fill(Color(UIColor.systemBackground))
                 graphView
             }
             .drawingGroup(opaque: true, colorMode: .extendedLinear)

--- a/Dynavity/Dynavity/view/graph/GraphView.swift
+++ b/Dynavity/Dynavity/view/graph/GraphView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct GraphView: View {
     private static let zoomScaleRange: ClosedRange<CGFloat> = 0.05...2.5
 
-    @EnvironmentObject var viewModel: GraphMapViewModel
+    @EnvironmentObject var viewModel: GraphViewModel
     @ObservedObject var canvasSelectionViewModel: CanvasSelectionViewModel
 
     // For viewport dragging gesture
@@ -134,6 +134,6 @@ extension GraphView {
 struct GraphView_Previews: PreviewProvider {
     static var previews: some View {
         GraphView(canvasSelectionViewModel: CanvasSelectionViewModel(), searchQuery: .constant("Hello"))
-            .environmentObject(GraphMapViewModel())
+            .environmentObject(GraphViewModel())
     }
 }

--- a/Dynavity/Dynavity/view/graph/GraphView.swift
+++ b/Dynavity/Dynavity/view/graph/GraphView.swift
@@ -41,7 +41,7 @@ struct GraphView: View {
 
     var nodesView: some View {
         ZStack {
-            ForEach(viewModel.getNodes(), id: \.id) { node in
+            ForEach(viewModel.getNodes(), id: \.self) { node in
                 Group {
                     // Solution referenced from https://stackoverflow.com/a/65401199
                     // If the current node has been long pressed, it means that we want to automatically

--- a/Dynavity/DynavityTests/orthogonal-connector/GridTests.swift
+++ b/Dynavity/DynavityTests/orthogonal-connector/GridTests.swift
@@ -104,8 +104,10 @@ class GridTests: XCTestCase {
     }
 
     func testGenerateGridPoints() {
-        let sourceUmlElement: UmlElementProtocol = RectangleUmlElement(position: CGPoint(x: 250, y: 250))
-        let destinationUmlElement: UmlElementProtocol = RectangleUmlElement(position: CGPoint(x: 1_000, y: 1_000))
+        let sourceUmlElement: UmlElementProtocol = ActivityUmlElement(position: CGPoint(x: 250, y: 250),
+                                                                      shape: .rectangle)
+        let destinationUmlElement: UmlElementProtocol = ActivityUmlElement(position: CGPoint(x: 1_000, y: 1_000),
+                                                                           shape: .rectangle)
         let points = orthogonalConnectorGrid
             .generateGridPoints(fromElement: sourceUmlElement, toElement: destinationUmlElement)
         XCTAssertEqual(points.count, 131)


### PR DESCRIPTION
Changes:
- Removed ID from BacklinkNode. Nodes must now be uniquely identified by their names
- Add storage of backlinks (adding of nodes, deleting of nodes, renaming of nodes)
  - Adding a node creates a node placed randomly in the graph
  - Deleting a node deletes the node and all connected edges
  - Renaming a node should preserve all edges
  - Adding / removing of edges can be done in the sidemenu of the respective canvases.
  - Longpressing on a node should go to corresponding canvas