### PR TITLE
Add stronger validation on canvas names

### DIFF
--- a/Dynavity/Dynavity/view-model/CanvasSelectionViewModel.swift
+++ b/Dynavity/Dynavity/view-model/CanvasSelectionViewModel.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 class CanvasSelectionViewModel: ObservableObject {
+    static let canvasNameLengthLimit = 20
     private let canvasRepo = CanvasRepository()
 
     @Published var selectedCanvases: [Canvas] = []
@@ -56,8 +57,13 @@ class CanvasSelectionViewModel: ObservableObject {
         self.objectWillChange.send()
     }
 
+    // A string is a valid canvas name if and only if it is non-empty, consists of only
+    // alphanumeric characters, is unique, and is less than 20 characters long. Spaces are allowed.
+    // Canvas names are not case-sensitive.
     func isValidCanvasName(name: String) -> Bool {
-        !name.isEmpty && isCanvasNameUnique(name: name)
+        let consistsOfOnlyAlphanumeric = name.range(of: "[^a-zA-Z0-9 ]", options: .regularExpression) == nil
+        let isWithinLengthLimit = name.count < CanvasSelectionViewModel.canvasNameLengthLimit
+        return !name.isEmpty && consistsOfOnlyAlphanumeric && isCanvasNameUnique(name: name) && isWithinLengthLimit
     }
 
     // Case-insensitive checking

--- a/Dynavity/Dynavity/view/CanvasSelectionView.swift
+++ b/Dynavity/Dynavity/view/CanvasSelectionView.swift
@@ -156,7 +156,8 @@ extension CanvasSelectionView {
             textField.text = "\(canvas.name)"
         }
         alert.addAction(UIAlertAction(title: "Save", style: .default, handler: { _ in
-            guard let updatedName = alert.textFields?.first?.text else {
+            guard let updatedName = alert.textFields?
+                    .first?.text?.trimmingCharacters(in: .whitespacesAndNewlines) else {
                 return
             }
 
@@ -201,7 +202,8 @@ extension CanvasSelectionView {
             textField.placeholder = "Enter canvas name here"
         }
         alert.addAction(UIAlertAction(title: "Save", style: .default, handler: { _ in
-            guard let updatedName = alert.textFields?.first?.text else {
+            guard let updatedName = alert.textFields?
+                    .first?.text?.trimmingCharacters(in: .whitespacesAndNewlines) else {
                 return
             }
 
@@ -218,8 +220,12 @@ extension CanvasSelectionView {
     }
 
     private func invalidCanvasNameHandler() {
+        let invalidMessage = "Canvas name must be a unique, non-empty string, "
+            + "consisting of less than \(CanvasSelectionViewModel.canvasNameLengthLimit) "
+            + "alphanumeric characters or spaces. "
+            + "Canvas names are not case-sensitive."
         let errorAlert = UIAlertController(title: "Invalid canvas name!",
-                                           message: "Canvas names must be unique and non-empty.",
+                                           message: invalidMessage,
                                            preferredStyle: .alert)
         errorAlert.addAction(UIAlertAction(title: "Dismiss", style: .cancel, handler: nil))
         self.showAlert(alert: errorAlert)


### PR DESCRIPTION
"Canvas name must be a unique, non-empty string, consisting of less than 20 alphanumeric characters or spaces. Canvas names are not case-sensitive."
- This is the conditions imposed on a canvas name and is also the error message that is shown to the users.
- (Is this error message too long?)