### PR TITLE
Polish keyboard behaviour

### DIFF
--- a/Dynavity/Dynavity/view/MainView.swift
+++ b/Dynavity/Dynavity/view/MainView.swift
@@ -45,6 +45,7 @@ struct MainView: View {
     var umlMenuButton: some View {
         Button(action: {
             canvasViewModel.showUmlMenu()
+            self.closeKeyboard()
         }) {
             Image(systemName: "arrow.right.square").resizable()
         }
@@ -70,6 +71,7 @@ struct MainView: View {
                 sideMenu
                 umlMenu
             }
+            .ignoresSafeArea(.keyboard)
             .navigationBarHidden(true)
         }.navigationViewStyle(StackNavigationViewStyle())
     }

--- a/Dynavity/Dynavity/view/canvas/CanvasView.swift
+++ b/Dynavity/Dynavity/view/canvas/CanvasView.swift
@@ -17,6 +17,7 @@ struct CanvasView: View {
                 AnnotationCanvasView(viewModel: viewModel)
                     .disabled(viewModel.canvasMode == .selection)
             }
+            .ignoresSafeArea(.keyboard)
             .onAppear {
                 viewModel.setCanvasViewport(size: geometry.size)
             }

--- a/Dynavity/Dynavity/view/canvas/CanvasView.swift
+++ b/Dynavity/Dynavity/view/canvas/CanvasView.swift
@@ -9,6 +9,7 @@ struct CanvasView: View {
                 AnnotationCanvasView(viewModel: viewModel, isDrawingDisabled: true)
                     .onTapGesture {
                         viewModel.unselectCanvasElement()
+                        self.closeKeyboard()
                     }
                 CanvasElementMapView(viewModel: viewModel)
                     .scaleEffect(viewModel.scaleFactor)

--- a/Dynavity/Dynavity/view/extensions/View+closeKeyboard.swift
+++ b/Dynavity/Dynavity/view/extensions/View+closeKeyboard.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+extension View {
+    func closeKeyboard() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+}


### PR DESCRIPTION
Previously, whenever the keyboard appears, the `CanvasElementMapView` would be shifted upwards, but not the `AnnotationCanvasView`s. This caused the annotations to be offset from the canvas elements. This PR disables the keyboard avoidance behaviour such that the `CanvasElementMapView` no longer shifts upwards when the keyboard is opened. With or without the keyboard avoidance behaviour, there will always be instances where the keyboard blocks the view of whatever is being typed.

In addition, the keyboard is now closed if the user taps on the background of the canvas, or opens the UML diagram menu.