### PR TITLE
Fix canvas elements & annotations being out of sync

### DIFF
--- a/Dynavity/Dynavity/view/canvas/CanvasView.swift
+++ b/Dynavity/Dynavity/view/canvas/CanvasView.swift
@@ -17,7 +17,10 @@ struct CanvasView: View {
                     .disabled(viewModel.canvasMode == .selection)
             }
             .onAppear {
-                viewModel.setCanvasViewport(size: geometry.size)
+                // Slight delay for the ZStack to resize itself, else the GeometryReader will not be accurate.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    viewModel.setCanvasViewport(size: geometry.size)
+                }
             }
             .onReceive(viewModel.autoSavePublisher, perform: { _ in
                 viewModel.saveCanvas()


### PR DESCRIPTION
No idea why this is the case. I spent so long debugging my calculations before I realised that the problem was due to the wrong viewport size being reported.