### PR TITLE
Implement canvas-level collaboration

### DIFF
--- a/Dynavity/Dynavity/model/canvas/OnlineCanvas.swift
+++ b/Dynavity/Dynavity/model/canvas/OnlineCanvas.swift
@@ -4,11 +4,12 @@ import SwiftUI
 class OnlineCanvas: Canvas {
     static let myUserId = UIDevice.current.identifierForVendor?.uuidString
             ?? "NO_USER_ID"
+    static let delimiter: Character = "/"
 
     let ownerId: String
     var shareableId: String {
         // note that since / is a delimiter, it must not appear in either field
-        "\(ownerId)/\(name)"
+        "\(ownerId)\(OnlineCanvas.delimiter)\(name)"
     }
 
     /// Used to publish a user's `CanvasWithAnnotation` as an `OnlineCanvas`.

--- a/Dynavity/Dynavity/persistence/repositories/CanvasRepository.swift
+++ b/Dynavity/Dynavity/persistence/repositories/CanvasRepository.swift
@@ -93,6 +93,12 @@ struct CanvasRepository: Repository {
     }
 
     func importCanvas(ownerId: String, canvasName: String) -> Bool {
-        false
+        do {
+            let canvas = try cloudStorageManager.importCanvas(ownerId: ownerId, canvasName: canvasName)
+            return canvas != nil
+        } catch {
+            return false
+        }
+
     }
 }

--- a/Dynavity/Dynavity/persistence/repositories/CanvasRepository.swift
+++ b/Dynavity/Dynavity/persistence/repositories/CanvasRepository.swift
@@ -91,4 +91,8 @@ struct CanvasRepository: Repository {
         try? localStorageManager.readAll()
             .first(where: { $0.name == canvas.name })?.id
     }
+
+    func importCanvas(ownerId: String, canvasName: String) -> Bool {
+        false
+    }
 }

--- a/Dynavity/Dynavity/persistence/repositories/CanvasRepository.swift
+++ b/Dynavity/Dynavity/persistence/repositories/CanvasRepository.swift
@@ -59,7 +59,7 @@ struct CanvasRepository: Repository {
         }
     }
 
-    func deleteLocal(model: Canvas) -> Bool {
+    private func deleteLocal(model: Canvas) -> Bool {
         let id = getExistingId(for: model) ?? UUID()
         let canvasDTO = CanvasDTO(id: id, model: model)
         do {
@@ -70,7 +70,7 @@ struct CanvasRepository: Repository {
         }
     }
 
-    func deleteCloud(model: OnlineCanvas) -> Bool {
+    private func deleteCloud(model: OnlineCanvas) -> Bool {
         do {
             try cloudStorageManager.delete(model: OnlineCanvasDTO(model: model))
             return true

--- a/Dynavity/Dynavity/persistence/repositories/CanvasRepository.swift
+++ b/Dynavity/Dynavity/persistence/repositories/CanvasRepository.swift
@@ -99,6 +99,5 @@ struct CanvasRepository: Repository {
         } catch {
             return false
         }
-
     }
 }

--- a/Dynavity/Dynavity/persistence/storage/CloudStorageManager.swift
+++ b/Dynavity/Dynavity/persistence/storage/CloudStorageManager.swift
@@ -28,35 +28,38 @@ struct CloudStorageManager: OnlineStorageManager {
                 callback(.success(canvases))
             }
         }
-        let ownCanvases = FutureSynchronizer(publisher: ownFuture).blockForValue()
+        let ownCanvases = FutureSynchronizer(publisher: ownFuture).blockForValue() ?? []
         // other cloud canvases (from collab)
         let collab = database.reference(withPath: "\(userId)/collab")
-        let collabFuture = Future<[OnlineCanvasDTO], Never> { callback in
+        let collabListFuture = Future<[ExternalCanvasReference], Never> { callback in
             collab.getData { _, snapshot in
                 guard let value = snapshot.value,
                       let loaded = try? decoder.decode([ExternalCanvasReference].self, from: value) else {
                     // if something is wrong, 'success' with empty value
                     return callback(.success([]))
                 }
-                let futures = loaded.map { ref in
-                    Future<OnlineCanvasDTO, Never> { callback in
-                        let db = database.reference(withPath: "\(ref.ownerId)/self/\(ref.canvasName)")
-                        db.getData { _, snapshot in
-                            guard let value = snapshot.value,
-                                  let loaded = try? decoder.decode(CanvasDTO.self, from: value) else {
-                                return
-                            }
-                            let canvas = OnlineCanvasDTO(ownerId: ref.ownerId, canvas: loaded)
-                            callback(.success(canvas))
-                        }
-                    }
-                }
-                let canvases = MultiFutureSynchronizer(publishers: futures).blockForValue()
-                callback(.success(canvases))
+                callback(.success(loaded))
             }
         }
-        let collabCanvases = FutureSynchronizer(publisher: collabFuture).blockForValue()
-        return (ownCanvases ?? []) + (collabCanvases ?? [])
+        guard let collabList = FutureSynchronizer(publisher: collabListFuture).blockForValue() else {
+            return ownCanvases
+        }
+        let collabFuture = collabList.map { ref in
+            Future<OnlineCanvasDTO?, Never> { callback in
+                let db = database.reference(withPath: "\(ref.ownerId)/self/\(ref.canvasName)")
+                db.getData { _, snapshot in
+                    guard let value = snapshot.value,
+                          let loaded = try? decoder.decode(CanvasDTO.self, from: value) else {
+                        return callback(.success(nil))
+                    }
+                    let canvas = OnlineCanvasDTO(ownerId: ref.ownerId, canvas: loaded)
+                    callback(.success(canvas))
+                }
+            }
+        }
+        let collabCanvases = MultiFutureSynchronizer(publishers: collabFuture).blockForValue()
+            .compactMap { $0 }
+        return ownCanvases + collabCanvases
     }
 
     func save(model canvas: OnlineCanvasDTO) throws {
@@ -112,18 +115,18 @@ struct CloudStorageManager: OnlineStorageManager {
         guard let canvas = FutureSynchronizer(publisher: checkFuture).blockForValue() else {
             return nil
         }
-
         // success, add to current collab list
         let collab = database.reference(withPath: "\(userId)/collab")
         let collabFuture = Future<Void, Never> { callback in
             collab.getData { _, snapshot in
+                let ref = ExternalCanvasReference(ownerId: ownerId, canvasName: canvasName)
                 guard let value = snapshot.value,
                       var loaded = try? decoder.decode([ExternalCanvasReference].self, from: value) else {
-                    // if something is wrong, 'success' with empty value
+                    collab.setValue(try? encoder.encode([ref]))
                     return callback(.success(Void()))
                 }
-                loaded.append(ExternalCanvasReference(ownerId: ownerId, canvasName: canvasName))
-                collab.setValue(loaded)
+                loaded.append(ref)
+                collab.setValue(try? encoder.encode(loaded))
                 callback(.success(Void()))
             }
         }

--- a/Dynavity/Dynavity/persistence/storage/StorageManager.swift
+++ b/Dynavity/Dynavity/persistence/storage/StorageManager.swift
@@ -12,5 +12,5 @@ protocol OfflineStorageManager: StorageManager where ModelDTO == CanvasDTO {
 }
 
 protocol OnlineStorageManager: StorageManager where ModelDTO == OnlineCanvasDTO {
-
+    func importCanvas(ownerId: String, canvasName: String) throws -> OnlineCanvasDTO?
 }

--- a/Dynavity/Dynavity/view-model/CanvasSelectionViewModel.swift
+++ b/Dynavity/Dynavity/view-model/CanvasSelectionViewModel.swift
@@ -57,6 +57,10 @@ class CanvasSelectionViewModel: ObservableObject {
         self.objectWillChange.send()
     }
 
+    func importCanvas(name: String, owner: String) -> Bool {
+        canvasRepo.importCanvas(ownerId: owner, canvasName: name)
+    }
+
     // A string is a valid canvas name if and only if it is non-empty, consists of only
     // alphanumeric characters, is unique, and is less than 20 characters long. Spaces are allowed.
     // Canvas names are not case-sensitive.

--- a/Dynavity/Dynavity/view-model/CanvasSelectionViewModel.swift
+++ b/Dynavity/Dynavity/view-model/CanvasSelectionViewModel.swift
@@ -58,7 +58,9 @@ class CanvasSelectionViewModel: ObservableObject {
     }
 
     func importCanvas(name: String, owner: String) -> Bool {
-        canvasRepo.importCanvas(ownerId: owner, canvasName: name)
+        let result = canvasRepo.importCanvas(ownerId: owner, canvasName: name)
+        self.objectWillChange.send()
+        return result
     }
 
     // A string is a valid canvas name if and only if it is non-empty, consists of only

--- a/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
+++ b/Dynavity/Dynavity/view-model/canvas/CanvasViewModel.swift
@@ -131,6 +131,7 @@ class CanvasViewModel: ObservableObject {
 extension CanvasViewModel {
     func saveCanvas() {
         self.canvasRepo.save(model: canvas)
+        self.objectWillChange.send()
     }
 }
 
@@ -144,6 +145,7 @@ extension CanvasViewModel {
         canvasRepo.delete(model: canvas)
         canvas = OnlineCanvas(canvas: canvas)
         canvasRepo.save(model: canvas)
+        self.objectWillChange.send()
     }
 }
 

--- a/Dynavity/Dynavity/view/CanvasSelectionView.swift
+++ b/Dynavity/Dynavity/view/CanvasSelectionView.swift
@@ -235,7 +235,7 @@ extension CanvasSelectionView {
         alert.addTextField { textField in
             textField.placeholder = "Enter shareable ID here"
         }
-        alert.addAction(UIAlertAction(title: "Save", style: .default, handler: { _ in
+        alert.addAction(UIAlertAction(title: "Import", style: .default, handler: { _ in
             guard let shareID = alert.textFields?
                     .first?.text?.trimmingCharacters(in: .whitespacesAndNewlines) else {
                 return

--- a/Dynavity/Dynavity/view/CanvasSelectionView.swift
+++ b/Dynavity/Dynavity/view/CanvasSelectionView.swift
@@ -209,6 +209,30 @@ extension CanvasSelectionView {
     private func onNewCanvasButtonTap() {
         let alert = UIAlertController(title: "New canvas", message: nil, preferredStyle: .alert)
         alert.addTextField { textField in
+            textField.placeholder = "Enter canvas name here"
+        }
+        alert.addAction(UIAlertAction(title: "Save", style: .default, handler: { _ in
+            guard let updatedName = alert.textFields?
+                    .first?.text?.trimmingCharacters(in: .whitespacesAndNewlines) else {
+                return
+            }
+
+            let isNewNameUnique = viewModel.isValidCanvasName(name: updatedName)
+
+            if isNewNameUnique {
+                viewModel.createCanvas(name: updatedName)
+                graphViewModel.addNode(name: updatedName)
+            } else {
+                invalidCanvasNameHandler()
+            }
+        }))
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        self.showAlert(alert: alert)
+    }
+
+    private func onImportCanvasButtonTap() {
+        let alert = UIAlertController(title: "Import shared canvas", message: nil, preferredStyle: .alert)
+        alert.addTextField { textField in
             textField.placeholder = "Enter shareable ID here"
         }
         alert.addAction(UIAlertAction(title: "Save", style: .default, handler: { _ in
@@ -229,35 +253,10 @@ extension CanvasSelectionView {
             let isNewNameUnique = viewModel.isValidCanvasName(name: canvasName)
 
             if isNewNameUnique {
-                guard viewModel.importCanvas(name: canvasName, owner: ownerID) else {
+                if !viewModel.importCanvas(name: canvasName, owner: ownerID) {
                     sharedCanvasDoesNotExistHandler()
-                    return
                 }
                 // shared canvas does not appear in graph view model
-            } else {
-                invalidCanvasNameHandler()
-            }
-        }))
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
-        self.showAlert(alert: alert)
-    }
-
-    private func onImportCanvasButtonTap() {
-        let alert = UIAlertController(title: "Import shared canvas", message: nil, preferredStyle: .alert)
-        alert.addTextField { textField in
-            textField.placeholder = "Enter canvas name here"
-        }
-        alert.addAction(UIAlertAction(title: "Save", style: .default, handler: { _ in
-            guard let updatedName = alert.textFields?
-                    .first?.text?.trimmingCharacters(in: .whitespacesAndNewlines) else {
-                return
-            }
-
-            let isNewNameUnique = viewModel.isValidCanvasName(name: updatedName)
-
-            if isNewNameUnique {
-                viewModel.createCanvas(name: updatedName)
-                graphViewModel.addNode(name: updatedName)
             } else {
                 invalidCanvasNameHandler()
             }

--- a/Dynavity/Dynavity/view/CanvasSelectionView.swift
+++ b/Dynavity/Dynavity/view/CanvasSelectionView.swift
@@ -129,6 +129,11 @@ struct CanvasSelectionView: View {
                 }) {
                     Image(systemName: "doc.fill.badge.plus")
                 }
+                Button(action: {
+                    onImportCanvasButtonTap()
+                }) {
+                    Image(systemName: "person.fill.badge.plus")
+                }
             }
         }
     }
@@ -204,6 +209,42 @@ extension CanvasSelectionView {
     private func onNewCanvasButtonTap() {
         let alert = UIAlertController(title: "New canvas", message: nil, preferredStyle: .alert)
         alert.addTextField { textField in
+            textField.placeholder = "Enter shareable ID here"
+        }
+        alert.addAction(UIAlertAction(title: "Save", style: .default, handler: { _ in
+            guard let shareID = alert.textFields?
+                    .first?.text?.trimmingCharacters(in: .whitespacesAndNewlines) else {
+                return
+            }
+
+            let parts = shareID.split(separator: OnlineCanvas.delimiter)
+            guard parts.count == 2 else {
+                invalidShareHandler()
+                return
+            }
+
+            let ownerID = String(parts[0])
+            let canvasName = String(parts[1])
+            // name still has to be unique within this device
+            let isNewNameUnique = viewModel.isValidCanvasName(name: canvasName)
+
+            if isNewNameUnique {
+                guard viewModel.importCanvas(name: canvasName, owner: ownerID) else {
+                    sharedCanvasDoesNotExistHandler()
+                    return
+                }
+                // shared canvas does not appear in graph view model
+            } else {
+                invalidCanvasNameHandler()
+            }
+        }))
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        self.showAlert(alert: alert)
+    }
+
+    private func onImportCanvasButtonTap() {
+        let alert = UIAlertController(title: "Import shared canvas", message: nil, preferredStyle: .alert)
+        alert.addTextField { textField in
             textField.placeholder = "Enter canvas name here"
         }
         alert.addAction(UIAlertAction(title: "Save", style: .default, handler: { _ in
@@ -230,8 +271,22 @@ extension CanvasSelectionView {
             + "consisting of less than \(CanvasSelectionViewModel.canvasNameLengthLimit) "
             + "alphanumeric characters or spaces. "
             + "Canvas names are not case-sensitive."
-        let errorAlert = UIAlertController(title: "Invalid canvas name!",
-                                           message: invalidMessage,
+        showErrorAlert(title: "Invalid canvas name!", message: invalidMessage)
+    }
+
+    private func invalidShareHandler() {
+        let invalidMessage = "Shareable ID should contain exactly one '\(OnlineCanvas.delimiter)' character."
+        showErrorAlert(title: "Invalid shareable ID!", message: invalidMessage)
+    }
+
+    private func sharedCanvasDoesNotExistHandler() {
+        let invalidMessage = "Shared canvas does not exist."
+        showErrorAlert(title: "Invalid shareable ID!", message: invalidMessage)
+    }
+
+    private func showErrorAlert(title: String, message: String) {
+        let errorAlert = UIAlertController(title: title,
+                                           message: message,
                                            preferredStyle: .alert)
         errorAlert.addAction(UIAlertAction(title: "Dismiss", style: .cancel, handler: nil))
         self.showAlert(alert: errorAlert)


### PR DESCRIPTION
This allows multiple devices to work on a common canvas.
1. On the canvas selection screen, there is a new icon next to the New Canvas button. This allows the user to import an already shared canvas on the cloud using the shared ID (implemented in #76).
  a. There is currently no way to efficiently copy the shared ID from the app (e.g. to share it with others). This is a QoL issue that can easily be fixed in future. 
  b. The imported canvas is represented on the backend as a "foreign key" of sorts, referring to the canvas stored under the original creator.
3. Any device will be able to work on a canvas as if though it were owned by that user. Writes will be visible to all users who either own or have imported that canvas.
4. The latest state is currently retrieved **once** from the backend **upon launch**, as is the case for all canvases.
  a. Note that working simultaneously on the same canvas (aka google docs behavior) is **not implemented yet**. If multiple devices are open with the same canvas, they will conflict with each other and cause undefined behavior.