### PR TITLE
Fix uml element deletion

### DIFF
--- a/Dynavity/Dynavity/model/canvas/Canvas.swift
+++ b/Dynavity/Dynavity/model/canvas/Canvas.swift
@@ -36,8 +36,25 @@ class Canvas: ObservableObject {
             return
         }
 
+        if element is UmlElementProtocol {
+            removeAttachedConnectors(element as? UmlElementProtocol)
+        }
         canvasElements.remove(at: index)
         canvasElementCancellables.remove(at: index)
+    }
+
+    private func removeAttachedConnectors(_ element: UmlElementProtocol?) {
+        guard let umlElement = element else {
+            return
+        }
+
+        for connector in umlConnectors {
+            if connector.connects.fromElement !== umlElement
+                    && connector.connects.toElement !== umlElement {
+                continue
+            }
+            removeUmlConnector(connector)
+        }
     }
 }
 

--- a/Dynavity/Dynavity/view/elements/uml-shapes/ActivityUmlElementView.swift
+++ b/Dynavity/Dynavity/view/elements/uml-shapes/ActivityUmlElementView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ActivityUmlElementView: View {
     @StateObject private var viewModel: UmlElementViewModel
+    private let backgroundOpacity: Double = 0.001
 
     init(umlElement: UmlElementProtocol) {
         self._viewModel = StateObject(wrappedValue: UmlElementViewModel(umlElement: umlElement))

--- a/Dynavity/Dynavity/view/elements/uml-shapes/ActivityUmlElementView.swift
+++ b/Dynavity/Dynavity/view/elements/uml-shapes/ActivityUmlElementView.swift
@@ -41,7 +41,7 @@ struct ActivityUmlElementView: View {
             }
             TextField("", text: $viewModel.umlElement.label)
                 .multilineTextAlignment(.center)
-        }.background(Color.white)
+        }.background(Color.white.opacity(backgroundOpacity))
     }
 }
 


### PR DESCRIPTION
Deleting UML elements now delete the `UmlConnector`s that are connected to it. This fixes the issue where loading from storage fails when `UmlConnector`s can not find the corresponding UML elements that were deleted.