### PR TITLE
Remove use of NavigationLink

### DIFF
--- a/Dynavity/Dynavity/view/MainView.swift
+++ b/Dynavity/Dynavity/view/MainView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct MainView: View {
+    @Environment(\.presentationMode) var presentationMode
     @StateObject private var canvasViewModel: CanvasViewModel
     @State private var shouldShowMenu = false
 
@@ -57,7 +58,8 @@ struct MainView: View {
         NavigationView {
             ZStack(alignment: .leading) {
                 VStack(spacing: 0.0) {
-                    ToolbarView(viewModel: canvasViewModel, shouldShowSideMenu: $shouldShowMenu)
+                    ToolbarView(viewModel: canvasViewModel, shouldShowSideMenu: $shouldShowMenu,
+                                canvasPresentationMode: presentationMode)
                     Divider()
                     CanvasView(viewModel: canvasViewModel)
                 }

--- a/Dynavity/Dynavity/view/ToolbarView.swift
+++ b/Dynavity/Dynavity/view/ToolbarView.swift
@@ -21,6 +21,7 @@ struct ToolbarView: View {
     @ObservedObject var viewModel: CanvasViewModel
     @State private var activeSheet: ActiveSheet?
     @Binding var shouldShowSideMenu: Bool
+    @Binding var canvasPresentationMode: PresentationMode
 
     let columns = [
         GridItem(.flexible()),
@@ -202,12 +203,11 @@ struct ToolbarView: View {
     }
 
     private var homeButton: some View {
-        NavigationLink(destination: CanvasSelectionView()
-                        .navigationBarHidden(true)
-                        .navigationBarBackButtonHidden(true)) {
+        Button(action: {
+            self.canvasPresentationMode.dismiss()
+        }) {
             Image(systemName: "house")
         }
-        .navigationBarHidden(true)
     }
 
     var body: some View {
@@ -250,7 +250,9 @@ struct ToolbarView: View {
 }
 
 struct ToolbarView_Previews: PreviewProvider {
+    @Environment(\.presentationMode) static var presentation
     static var previews: some View {
-        ToolbarView(viewModel: CanvasViewModel(), shouldShowSideMenu: .constant(true))
+        ToolbarView(viewModel: CanvasViewModel(), shouldShowSideMenu: .constant(true),
+                    canvasPresentationMode: presentation)
     }
 }


### PR DESCRIPTION
This should improve the memory not being freed from repeatedly navigating between a canvas and the homescreen