### PR TITLE
Fix strong reference cycle in closure

### DIFF
--- a/Dynavity/Dynavity/synchronization/FutureSynchronizer.swift
+++ b/Dynavity/Dynavity/synchronization/FutureSynchronizer.swift
@@ -13,8 +13,8 @@ class FutureSynchronizer<T> {
 
     func blockForValue() -> T? {
         let block = DispatchSemaphore(value: 0)
-        cancel = publisher.sink { value in
-            self.value = value
+        cancel = publisher.sink { [weak self] value in
+            self?.value = value
             block.signal()
         }
         block.wait()

--- a/Dynavity/Dynavity/synchronization/MultiFutureSynchronizer.swift
+++ b/Dynavity/Dynavity/synchronization/MultiFutureSynchronizer.swift
@@ -14,8 +14,8 @@ class MultiFutureSynchronizer<T> {
     func blockForValue() -> [T] {
         let block = DispatchSemaphore(value: 0)
         for publisher in publishers {
-            let cancel = publisher.sink { value in
-                self.values.append(value)
+            let cancel = publisher.sink { [weak self] value in
+                self?.values.append(value)
                 block.signal()
             }
             cancels.append(cancel)


### PR DESCRIPTION
With this, there should be no memory leaks in the application. Use the profiler to verify that this is true (with an emphasis on loading and exiting canvases).