### PR TITLE
Move methods from Canvas to OnlineCanvas

### DIFF
--- a/Dynavity/Dynavity/model/canvas/Canvas.swift
+++ b/Dynavity/Dynavity/model/canvas/Canvas.swift
@@ -46,24 +46,6 @@ class Canvas: ObservableObject {
         canvasElements.remove(at: index)
         canvasElementCancellables.remove(at: index)
     }
-
-    func replace(canvasElements: [CanvasElementProtocol]) {
-        self.canvasElements
-            .filter { !($0 is UmlElementProtocol) }
-            .forEach(removeElement)
-        canvasElements.forEach(addElement)
-    }
-
-    func replace(annotation: AnnotationCanvas) {
-        self.annotationCanvas = annotation
-    }
-
-    func replace(umlElements: [UmlElementProtocol], umlConnectors: [UmlConnector]) {
-        self.umlConnectors.forEach(removeUmlConnector)
-        self.umlElements.forEach(removeElement)
-        umlElements.forEach(addElement)
-        umlConnectors.forEach(addUmlConnector)
-    }
 }
 
 // MARK: UML Connectors

--- a/Dynavity/Dynavity/model/canvas/OnlineCanvas.swift
+++ b/Dynavity/Dynavity/model/canvas/OnlineCanvas.swift
@@ -22,4 +22,22 @@ class OnlineCanvas: Canvas {
         self.ownerId = ownerId
         super.init(canvas: canvas)
     }
+
+    func replace(canvasElements: [CanvasElementProtocol]) {
+        self.canvasElements
+            .filter { !($0 is UmlElementProtocol) }
+            .forEach(removeElement)
+        canvasElements.forEach(addElement)
+    }
+
+    func replace(annotation: AnnotationCanvas) {
+        self.annotationCanvas = annotation
+    }
+
+    func replace(umlElements: [UmlElementProtocol], umlConnectors: [UmlConnector]) {
+        self.umlConnectors.forEach(removeUmlConnector)
+        self.umlElements.forEach(removeElement)
+        umlElements.forEach(addElement)
+        umlConnectors.forEach(addUmlConnector)
+    }
 }


### PR DESCRIPTION
Only an `OnlineCanvas` needs to be able to `replace` properties.